### PR TITLE
test: docs-only PR to validate CI skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,3 +544,4 @@ Hook scripts use the equivalence sets from `hook-utils.ts` (e.g. `isShellTool("r
 **Codex CLI** — has `AfterAgent` and `AfterToolUse` hook events in its Rust crate, but no user-facing config file for hooks yet. Tool name mappings are tracked and ready for when user-configurable hooks ship.
 
 **Claude Code settings revert** — a running Claude Code process watches `~/.claude/settings.json` and may revert writes within ~1.5 seconds. Close all Claude Code sessions before running `swiz install`, or the changes won't persist.
+<!-- ci-skip validation -->


### PR DESCRIPTION
Validation PR — only README.md changed. CI should not trigger due to paths-ignore.