### PR TITLE
fix(hooks): make changelog staleness detection repo-relative

### DIFF
--- a/hooks/stop-auto-continue.test.ts
+++ b/hooks/stop-auto-continue.test.ts
@@ -1516,6 +1516,28 @@ describe("stop-auto-continue", () => {
     await run(["git", "remote", "add", "origin", remoteUrl])
   }
 
+  async function runGit(
+    dir: string,
+    args: string[],
+    envOverrides: Record<string, string> = {}
+  ): Promise<void> {
+    const proc = Bun.spawn(["git", ...args], {
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        ...envOverrides,
+      },
+    })
+    await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+    const exitCode = await proc.exited
+    if (exitCode !== 0) {
+      throw new Error(`git ${args.join(" ")} failed: ${stderr}`)
+    }
+  }
+
   /**
    * Creates a fake `gh` bun script that serves fixture responses from env vars.
    * Env vars: GH_MOCK_USER, GH_MOCK_ISSUES, GH_MOCK_PRS.
@@ -1635,6 +1657,46 @@ describe("stop-auto-continue", () => {
     expect(result.decision).toBe("block")
     expect(result.reason).not.toContain("Note:")
     expect(result.reason).not.toContain("need refinement")
+  })
+
+  test("includes stale changelog warning when invoked from a nested cwd", async () => {
+    const repoDir = await createTempDir()
+    await initFakeGitRepo(repoDir, "https://github.com/testuser/testrepo.git")
+    await runGit(repoDir, ["config", "user.name", "Test User"])
+    await runGit(repoDir, ["config", "user.email", "test@example.com"])
+
+    await writeFile(join(repoDir, "CHANGELOG.md"), "# Changelog\n")
+    await runGit(repoDir, ["add", "CHANGELOG.md"])
+    await runGit(repoDir, ["commit", "-m", "Add changelog"], {
+      GIT_AUTHOR_DATE: "2026-03-24T10:00:00Z",
+      GIT_COMMITTER_DATE: "2026-03-24T10:00:00Z",
+    })
+
+    const nestedDir = join(repoDir, "src", "nested")
+    await mkdir(nestedDir, { recursive: true })
+    await writeFile(join(nestedDir, "feature.ts"), "export const value = 1\n")
+    await runGit(repoDir, ["add", "src/nested/feature.ts"])
+    await runGit(repoDir, ["commit", "-m", "Add nested feature"], {
+      GIT_AUTHOR_DATE: "2026-03-26T12:00:00Z",
+      GIT_COMMITTER_DATE: "2026-03-26T12:00:00Z",
+    })
+
+    const captureDir = await createTempDir()
+    const captureFile = join(captureDir, "prompt.txt")
+
+    await runHook({
+      transcriptContent: buildTranscript(10),
+      cwd: nestedDir,
+      extraEnv: {
+        GEMINI_API_KEY: "test-key",
+        AI_TEST_CAPTURE_FILE: captureFile,
+        AI_TEST_RESPONSE: agentResponse("Continue working"),
+      },
+    })
+
+    const capturedPrompt = await Bun.file(captureFile).text()
+    expect(capturedPrompt).toContain("=== PROJECT STATUS ===")
+    expect(capturedPrompt).toContain("CHANGELOG.md is stale")
   })
 })
 

--- a/hooks/stop-auto-continue.ts
+++ b/hooks/stop-auto-continue.ts
@@ -323,18 +323,18 @@ async function checkChangelogStaleness(cwd: string): Promise<string> {
   if (await Bun.file(`${repoRoot}/CHANGELOG.md`).exists()) {
     changelogPath = "CHANGELOG.md"
   } else {
-    const lsFiles = await git(["ls-files", repoRoot], cwd)
+    const lsFiles = await git(["ls-files"], repoRoot)
     const match = lsFiles.split("\n").find((f) => /^CHANGELOG\.md$/i.test(f))
     if (match) changelogPath = match
   }
 
   if (!changelogPath) return ""
 
-  const lastCommitTime = parseInt(await git(["log", "-1", "--format=%ct"], cwd), 10)
+  const lastCommitTime = parseInt(await git(["log", "-1", "--format=%ct"], repoRoot), 10)
   if (Number.isNaN(lastCommitTime)) return ""
 
   const changelogTime = parseInt(
-    await git(["log", "-1", "--format=%ct", "--", changelogPath], cwd),
+    await git(["log", "-1", "--format=%ct", "--", changelogPath], repoRoot),
     10
   )
   if (Number.isNaN(changelogTime)) return ""


### PR DESCRIPTION
## Summary
- run changelog discovery and git log checks from the repository root so nested working directories still detect stale `CHANGELOG.md`
- add a regression test covering hook execution from a nested cwd

## Testing
- `bun test hooks/stop-auto-continue.test.ts -t "includes stale changelog warning when invoked from a nested cwd"`
- manual QA: executed `hooks/stop-auto-continue.ts` from a nested cwd and verified the captured prompt included `CHANGELOG.md is stale — last updated 2d 2h before the most recent commit. It should be updated.`