### PR TITLE
docs(dispatch): document namespaced Codex apply_patch aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ The canonical manifest uses neutral names. At install time, `agents.ts` translat
 | Concept  | Claude Code    | Cursor         | Gemini CLI          | Codex CLI                        |
 |----------|----------------|----------------|---------------------|----------------------------------|
 | Shell    | `Bash`         | `Shell`        | `run_shell_command` | `shell_command` / `exec_command` |
-| Edit     | `Edit`         | `StrReplace`   | `replace`           | `apply_patch`                    |
-| Write    | `Write`        | `Write`        | `write_file`        | `apply_patch`                    |
+| Edit     | `Edit`         | `StrReplace`   | `replace`           | `apply_patch` / `functions.apply_patch` |
+| Write    | `Write`        | `Write`        | `write_file`        | `apply_patch` / `functions.apply_patch` |
 | Read     | `Read`         | `Read`         | `read_file`         | `read_file`                      |
 | Grep     | `Grep`         | `Grep`         | `grep_search`       | `grep_files`                     |
 | Glob     | `Glob`         | `Glob`         | `glob`              | `list_dir`                       |
-| Notebook | `NotebookEdit` | `EditNotebook` | —                   | `apply_patch`                    |
+| Notebook | `NotebookEdit` | `EditNotebook` | —                   | `apply_patch` / `functions.apply_patch` |
 | Tasks    | `TaskCreate`   | `TodoWrite`    | `write_todos`       | `spawn_agent`                    |
 
 **Event Names**

--- a/src/tool-matchers.ts
+++ b/src/tool-matchers.ts
@@ -7,12 +7,12 @@
 // Agent tool-name equivalences:
 //   Claude Code  | Cursor       | Codex              | Gemini
 //   Bash         | Shell        | run_shell_command  | run_shell_command
-//   Edit         | StrReplace   | replace            | replace
-//   Write        | Write        | write_file         | write_file
+// Edit | StrReplace | replace | apply_patch / functions.apply_patch
+// Write | Write | write_file | apply_patch / functions.apply_patch
 //   Read         | Read         | read_file          | read_file
 //   Grep         | Grep         | grep_search        | grep_search
 //   Glob         | Glob         | glob               | glob
-//   NotebookEdit | EditNotebook | —                  | —
+// NotebookEdit | EditNotebook | — | apply_patch / functions.apply_patch
 //   Task/planning| TodoWrite    | update_plan        | write_todos
 
 export const SHELL_TOOLS = new Set([


### PR DESCRIPTION
## Summary

* Updated the README Tool Names table to document `functions.apply_patch` alongside `apply_patch` for Codex edit, write, and notebook behavior.
* Updated the `src/tool-matchers.ts` cross-agent equivalence comment to match the current runtime tool sets.

Closes #726
