### PR TITLE
fix(dispatch): harden dispatch and daemon workflows

### DIFF
--- a/hooks/pretooluse-infraction-escalation.test.ts
+++ b/hooks/pretooluse-infraction-escalation.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { isDeny } from "../src/dispatch/engine.ts"
-import { COOLDOWN_MARKER } from "../src/infractions.ts"
+import { COOLDOWN_MARKER, INFRACTION_DENIAL_MARKER } from "../src/infractions.ts"
 import { evaluatePretooluseInfractionEscalation } from "./pretooluse-infraction-escalation.ts"
 
 const DENY_FOOTER = "You must act on this now"
@@ -88,6 +88,7 @@ describe("pretooluse-infraction-escalation", () => {
     )
     expect(isDeny(out)).toBe(true)
     expect(JSON.stringify(out)).toContain("re-assess")
+    expect(JSON.stringify(out)).toContain(INFRACTION_DENIAL_MARKER)
   })
 
   it("ignores denials of a different command", async () => {

--- a/hooks/pretooluse-infraction-escalation.ts
+++ b/hooks/pretooluse-infraction-escalation.ts
@@ -20,7 +20,12 @@
 // it does NOT fire on healthy-but-improvable advisory state — only on a concrete,
 // already-denied action being repeated. Pure transcript scan, no state files.
 
-import { COOLDOWN_MARKER, evaluateInfraction, resolveCurrentAttempt } from "../src/infractions.ts"
+import {
+  COOLDOWN_MARKER,
+  evaluateInfraction,
+  INFRACTION_DENIAL_MARKER,
+  resolveCurrentAttempt,
+} from "../src/infractions.ts"
 import {
   buildContextHookOutput,
   preToolUseDeny,
@@ -48,7 +53,7 @@ function yellowCardMessage(toolName: string, key: string): string {
 
 function redCardMessage(toolName: string, key: string, priorDenialCount: number): string {
   return (
-    `Blocked. You have retried ${describeAction(toolName, key)} ${priorDenialCount} times after it was denied, without taking the action the block required.\n\n` +
+    `Blocked by ${INFRACTION_DENIAL_MARKER}. You have retried ${describeAction(toolName, key)} ${priorDenialCount} times after it was denied, without taking the action the block required.\n\n` +
     `Stop retrying this call. Re-read the original deny message and take the action it asked for. ` +
     `If you genuinely believe the block is wrong, use the /re-assess skill rather than re-issuing the same call.`
   )

--- a/src/commands/daemon.test.ts
+++ b/src/commands/daemon.test.ts
@@ -23,7 +23,27 @@ import { hasSnapshotInvalidated } from "./daemon/snapshot.ts"
 import type { CapturedToolCall, SessionToolUsageState } from "./daemon/utils.ts"
 import { resolveComplianceDurationLabel } from "./daemon/web-server.ts"
 import { DaemonWorkerRuntime } from "./daemon/worker-runtime.ts"
-import { hydratePersistedSessionToolState } from "./daemon.ts"
+import {
+  deleteProjectSnapshots,
+  hydratePersistedSessionToolState,
+  snapshotCacheKey,
+} from "./daemon.ts"
+
+describe("project snapshot eviction", () => {
+  it("keeps sibling project snapshots that share a path prefix", () => {
+    const snapshots = new Map<string, object>([
+      [snapshotCacheKey("/workspace/app", "session-a"), {}],
+      [snapshotCacheKey("/workspace/app", "session-b"), {}],
+      [snapshotCacheKey("/workspace/app-api", "session-c"), {}],
+    ])
+
+    deleteProjectSnapshots(snapshots, "/workspace/app")
+
+    expect(snapshots.has(snapshotCacheKey("/workspace/app", "session-a"))).toBeFalse()
+    expect(snapshots.has(snapshotCacheKey("/workspace/app", "session-b"))).toBeFalse()
+    expect(snapshots.has(snapshotCacheKey("/workspace/app-api", "session-c"))).toBeTrue()
+  })
+})
 
 describe("snapshot resolver .finally() cleanup", () => {
   it("cleans up inFlight map after successful snapshot computation", async () => {

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -59,6 +59,21 @@ const TRANSCRIPT_MEMORY_RETENTION_MS = 30 * 60 * 1000 // 30 mins
 const TRANSCRIPT_MEMORY_PRUNE_INTERVAL_MS = 60 * 1000 // 1 min
 const PROJECT_IDLE_EVICTION_MS = 3 * 60 * 1000 // 3 mins
 const MAX_WATCHED_PROJECTS = 2
+const SNAPSHOT_KEY_SEPARATOR = "\x00"
+
+export function snapshotCacheKey(cwd: string, sessionId: string | null | undefined): string {
+  return `${cwd}${SNAPSHOT_KEY_SEPARATOR}${sessionId ?? ""}`
+}
+
+export function deleteProjectSnapshots(
+  snapshots: { keys(): Iterable<string>; delete(key: string): unknown },
+  cwd: string
+): void {
+  const prefix = snapshotCacheKey(cwd, null)
+  for (const key of snapshots.keys()) {
+    if (key.startsWith(prefix)) snapshots.delete(key)
+  }
+}
 
 async function handleDaemonSubcommand(args: string[], port: number): Promise<boolean> {
   if (args.includes("status")) {
@@ -177,9 +192,6 @@ function createDaemonCaches() {
 }
 
 function buildSnapshotResolver(snapshots: LRUCache<string, CachedSnapshot>) {
-  const cacheKey = (cwd: string, sessionId: string | null | undefined) =>
-    `${cwd}\x00${sessionId ?? ""}`
-
   // In-flight coalescing: concurrent requests for the same cwd+session share one computation.
   const inFlight = new Map<string, Promise<WarmStatusLineSnapshot>>()
 
@@ -187,7 +199,7 @@ function buildSnapshotResolver(snapshots: LRUCache<string, CachedSnapshot>) {
     cwd: string,
     sessionId: string | null | undefined
   ): Promise<WarmStatusLineSnapshot> => {
-    const key = cacheKey(cwd, sessionId)
+    const key = snapshotCacheKey(cwd, sessionId)
 
     // Coalesce concurrent callers before doing any expensive work.
     const inflight = inFlight.get(key)
@@ -266,9 +278,7 @@ function setupWatchers(
     // Do NOT unregister from upstreamSyncRegistry here — background sync continues
     // for idle projects so the issue store stays fresh without needing external triggers.
     caches.cooldownRegistry.invalidateProject(cwd)
-    for (const key of snapshots.keys()) {
-      if (key.startsWith(cwd)) snapshots.delete(key)
-    }
+    deleteProjectSnapshots(snapshots, cwd)
   }
 
   const invalidateProject = (cwd: string) => {
@@ -281,9 +291,7 @@ function setupWatchers(
     sessionDataCache.invalidateProject(cwd)
     invalidateTurnsCache(cwd)
     caches.cooldownRegistry.invalidateProject(cwd)
-    for (const key of snapshots.keys()) {
-      if (key.startsWith(cwd)) snapshots.delete(key)
-    }
+    deleteProjectSnapshots(snapshots, cwd)
   }
 
   const registerProjectWatchers = (cwd: string) => {

--- a/src/commands/daemon/upstream-sync.test.ts
+++ b/src/commands/daemon/upstream-sync.test.ts
@@ -87,6 +87,60 @@ describe("UpstreamSyncRegistry fork entries", () => {
   })
 })
 
+describe("UpstreamSyncRegistry lifecycle", () => {
+  test("keeps a timed-out sync in flight so the next interval cannot overlap it", async () => {
+    const releaseSync = deferred()
+    let syncCalls = 0
+    const store = new IssueStore(":memory:")
+    const registry = new UpstreamSyncRegistry({
+      intervalMs: 10,
+      timeoutMs: 5,
+      resolveSlug: async () => "owner/repo",
+      resolveFork: async () => null,
+      sync: async () => {
+        syncCalls++
+        await releaseSync.promise
+        return createSyncResult()
+      },
+      store,
+    })
+
+    try {
+      await registry.register("/virtual/repo")
+      await Bun.sleep(40)
+
+      expect(syncCalls).toBe(1)
+      expect(registry.listActive()[0]?.syncing).toBe(true)
+    } finally {
+      registry.close()
+      releaseSync.resolve()
+      await Bun.sleep(0)
+      store.close()
+    }
+  })
+
+  test("prunes a stored cwd cursor when startup registration fails", async () => {
+    const store = new IssueStore(":memory:")
+    store.setSyncCursor("owner/deleted", "cwd", "/deleted/repo")
+    const registry = new UpstreamSyncRegistry({
+      intervalMs: 60_000,
+      resolveSlug: async () => null,
+      resolveFork: async () => null,
+      store,
+    })
+
+    try {
+      await registry.restoreKnownRepos()
+
+      expect(store.getSyncCursor("owner/deleted", "cwd")).toBeNull()
+      expect(registry.listActive()).toHaveLength(0)
+    } finally {
+      registry.close()
+      store.close()
+    }
+  })
+})
+
 /**
  * A real on-disk project so realpath, the `.git` walk, and symlink aliasing are
  * exercised for real rather than mocked. `mkdtemp` lands under a symlinked

--- a/src/commands/daemon/upstream-sync.ts
+++ b/src/commands/daemon/upstream-sync.ts
@@ -36,6 +36,7 @@ interface SyncEntry {
 type RepoSlugResolver = (cwd: string) => Promise<string | null>
 type ForkTopologyResolver = (cwd: string) => Promise<{ upstreamSlug: string } | null>
 type SyncRunner = typeof syncUpstreamState
+type RegistrationResult = { deduped: boolean; registered: boolean }
 
 function toSyncStatus(entry: SyncEntry): UpstreamSyncStatus {
   return {
@@ -51,7 +52,7 @@ export class UpstreamSyncRegistry {
   private entries = new Map<string, SyncEntry>()
   // Registration coalescing: concurrent register() calls for cwd variants that
   // resolve to one root share a single computation. See register().
-  private inFlightRegistrations = new Map<string, Promise<{ deduped: boolean }>>()
+  private inFlightRegistrations = new Map<string, Promise<RegistrationResult>>()
   private readonly intervalMs: number
   private readonly timeoutMs: number
   private readonly resolveSlug: RepoSlugResolver
@@ -86,18 +87,18 @@ export class UpstreamSyncRegistry {
   /** Register a project for periodic upstream sync. Idempotent.
    *  For fork workflows, also registers the upstream (parent) repo so
    *  its issues, labels, and milestones are synced alongside the fork's PRs/CI. */
-  async register(cwd: string): Promise<{ deduped: boolean }> {
+  async register(cwd: string): Promise<RegistrationResult> {
     // Placeholder/relative cwds (e.g. "." from DaemonBackedIssueStore) must not
     // become sync entries — they resolve against the daemon's own cwd and spawn
     // a duplicate loop, and a persisted "." cursor would resurrect it on every
     // startup via restoreKnownRepos (#716).
-    if (!isRegisterableProjectCwd(cwd)) return { deduped: false }
+    if (!isRegisterableProjectCwd(cwd)) return { deduped: false, registered: false }
 
     // Key on the repository root, not the cwd we happened to be handed. `/path`,
     // `/path/`, a symlink alias, and `/path/subdir` all name one project; keying
     // raw gave each its own independent 2-minute sync loop (#717).
     const canonicalRoot = await resolveProjectRoot(cwd)
-    if (this.entries.has(canonicalRoot)) return { deduped: true }
+    if (this.entries.has(canonicalRoot)) return { deduped: true, registered: true }
 
     // restoreKnownRepos() registers every stored cursor concurrently, so two
     // legacy cwd variants collapsing to the same root can both clear the check
@@ -106,7 +107,10 @@ export class UpstreamSyncRegistry {
     const inflight = this.inFlightRegistrations.get(canonicalRoot)
     if (inflight) {
       await inflight
-      return { deduped: this.entries.has(canonicalRoot) }
+      return {
+        deduped: this.entries.has(canonicalRoot),
+        registered: this.entries.has(canonicalRoot),
+      }
     }
 
     const registration = this.performRegister(canonicalRoot)
@@ -118,9 +122,9 @@ export class UpstreamSyncRegistry {
     }
   }
 
-  private async performRegister(canonicalRoot: string): Promise<{ deduped: boolean }> {
+  private async performRegister(canonicalRoot: string): Promise<RegistrationResult> {
     const repo = await this.resolveSlug(canonicalRoot)
-    if (!repo) return { deduped: false }
+    if (!repo) return { deduped: false, registered: false }
 
     const entry: SyncEntry = {
       repo,
@@ -151,7 +155,7 @@ export class UpstreamSyncRegistry {
       }
     }
 
-    return { deduped: false }
+    return { deduped: false, registered: true }
   }
 
   /**
@@ -160,9 +164,14 @@ export class UpstreamSyncRegistry {
    * for every repo in the issue store without waiting for a dispatch to arrive.
    */
   async restoreKnownRepos(): Promise<void> {
-    const { getIssueStore } = await import("../../issue-store.ts")
-    const known = getIssueStore().listKnownRepoCwds()
-    await Promise.all(known.map(({ cwd }) => this.register(cwd)))
+    const store = this.store ?? getIssueStore()
+    const known = store.listKnownRepoCwds()
+    await Promise.all(
+      known.map(async ({ repo, cwd }) => {
+        const result = await this.register(cwd)
+        if (!result.registered) store.deleteSyncCursor(repo, "cwd")
+      })
+    )
   }
 
   /** Trigger an immediate sync for a project. Accepts any cwd inside it. */
@@ -246,18 +255,38 @@ export class UpstreamSyncRegistry {
 
     const computation = this.runSync(entry)
     this.inFlightSyncs.set(entryKey, computation)
-    return computation.finally(() => this.inFlightSyncs.delete(entryKey))
+    void computation.finally(() => {
+      if (this.inFlightSyncs.get(entryKey) === computation) {
+        this.inFlightSyncs.delete(entryKey)
+      }
+    })
+    return this.waitForSync(entry, computation)
+  }
+
+  private async waitForSync(
+    entry: SyncEntry,
+    computation: Promise<UpstreamSyncResult>
+  ): Promise<UpstreamSyncResult> {
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    try {
+      return await Promise.race([
+        computation,
+        new Promise<UpstreamSyncResult>((_, reject) => {
+          timeout = setTimeout(() => reject(new Error("sync timeout")), this.timeoutMs)
+        }),
+      ])
+    } catch (err) {
+      debugLog(`[swiz] UPSTREAM_SYNC_ERROR repo=${entry.repo} ${messageFromUnknownError(err)}`)
+      return entry.lastResult ?? createEmptySyncResult()
+    } finally {
+      if (timeout) clearTimeout(timeout)
+    }
   }
 
   private async runSync(entry: SyncEntry): Promise<UpstreamSyncResult> {
     entry.syncing = true
     try {
-      const result = await Promise.race([
-        this.sync(entry.repo, entry.cwd, { store: this.store ?? undefined }),
-        new Promise<UpstreamSyncResult>((_, reject) =>
-          setTimeout(() => reject(new Error("sync timeout")), this.timeoutMs)
-        ),
-      ])
+      const result = await this.sync(entry.repo, entry.cwd, { store: this.store ?? undefined })
       // Only stamp lastSyncAt on a real success — a sync where every fetch
       // returned null must not report as fresh to status/staleness consumers (#715).
       if (result.fetchOk) entry.lastSyncAt = Date.now()
@@ -275,27 +304,29 @@ export class UpstreamSyncRegistry {
       return result
     } catch (err) {
       debugLog(`[swiz] UPSTREAM_SYNC_ERROR repo=${entry.repo} ${messageFromUnknownError(err)}`)
-      const emptyBucket = () => ({ upserted: 0, removed: 0, skipped: 0, changes: [] })
-      const emptyTracked = () => ({ upserted: 0, changes: [] })
-      return (
-        entry.lastResult ?? {
-          issues: emptyBucket(),
-          pullRequests: emptyBucket(),
-          ciStatuses: emptyTracked(),
-          comments: { upserted: 0 },
-          labels: emptyBucket(),
-          milestones: emptyBucket(),
-          branchCi: emptyTracked(),
-          prBranchDetail: emptyTracked(),
-          branchProtection: emptyTracked(),
-          events: { inserted: 0, cursor: null },
-          restCache: { requests: 0, notModified: 0, writes: 0 },
-          fetchOk: false,
-        }
-      )
+      return entry.lastResult ?? createEmptySyncResult()
     } finally {
       entry.syncing = false
     }
+  }
+}
+
+function createEmptySyncResult(): UpstreamSyncResult {
+  const emptyBucket = () => ({ upserted: 0, removed: 0, skipped: 0, changes: [] })
+  const emptyTracked = () => ({ upserted: 0, changes: [] })
+  return {
+    issues: emptyBucket(),
+    pullRequests: emptyBucket(),
+    ciStatuses: emptyTracked(),
+    comments: { upserted: 0 },
+    labels: emptyBucket(),
+    milestones: emptyBucket(),
+    branchCi: emptyTracked(),
+    prBranchDetail: emptyTracked(),
+    branchProtection: emptyTracked(),
+    events: { inserted: 0, cursor: null },
+    restCache: { requests: 0, notModified: 0, writes: 0 },
+    fetchOk: false,
   }
 }
 

--- a/src/commands/dispatch-formats.test.ts
+++ b/src/commands/dispatch-formats.test.ts
@@ -130,6 +130,15 @@ async function writeTask(
   )
 }
 
+async function enableAutoContinue(homeDir: string): Promise<void> {
+  const { getSwizSettingsPath, invalidateSettingsCache, readSwizSettings, writeSwizSettings } =
+    await import("../settings.ts")
+  const defaults = await readSwizSettings({ home: homeDir })
+  await writeSwizSettings({ ...defaults, autoContinue: true }, { home: homeDir })
+  const settingsPath = getSwizSettingsPath(homeDir)
+  if (settingsPath) invalidateSettingsCache(settingsPath)
+}
+
 describe("dispatch output formats", () => {
   test("preToolUse deny uses hookSpecificOutput.permissionDecision", async () => {
     const homeDir = await _tmp.create("swiz-dispatch-home-")
@@ -191,6 +200,7 @@ describe("dispatch output formats", () => {
 
   test("stop block uses top-level decision + reason", async () => {
     const homeDir = await _tmp.create("swiz-dispatch-home-")
+    await enableAutoContinue(homeDir)
     const repoDir = await _tmp.create("swiz-dispatch-repo-")
     const transcriptPath = join(repoDir, "transcript.jsonl")
     await writeFile(

--- a/src/commands/dispatch.test.ts
+++ b/src/commands/dispatch.test.ts
@@ -569,6 +569,47 @@ describe("dispatch replay", () => {
     }
   }, 60_000)
 
+  test("SKILL.md-only replay bypasses preToolUse blocker groups", async () => {
+    const result = await replay(
+      "preToolUse",
+      {
+        tool_name: "apply_patch",
+        tool_input: {
+          command: [
+            "*** Begin Patch",
+            "*** Update File: .codex/skills/commit/SKILL.md",
+            "*** End Patch",
+          ].join("\n"),
+        },
+      },
+      ["--json"]
+    )
+
+    expect(result.exitCode).toBe(0)
+    const parsed = JSON.parse(result.stdout) as Record<string, any>
+    expect(parsed.matched_groups).toBe(0)
+    expect(parsed.hooks).toEqual([])
+    expect((parsed.result as Record<string, any>).blocked).toBe(false)
+  }, 60_000)
+
+  test("non-SKILL.md replay keeps preToolUse blocker groups active", async () => {
+    const result = await replay(
+      "preToolUse",
+      {
+        tool_name: "apply_patch",
+        tool_input: {
+          command: "*** Begin Patch\n*** Update File: src/main.ts\n*** End Patch",
+        },
+      },
+      ["--json"]
+    )
+
+    expect(result.exitCode).toBe(0)
+    const parsed = JSON.parse(result.stdout) as Record<string, any>
+    expect(parsed.matched_groups).toBeGreaterThan(0)
+    expect((parsed.hooks as Array<Record<string, any>>).length).toBeGreaterThan(0)
+  }, 60_000)
+
   test("replay outputs human-readable trace to stderr (non-JSON mode)", async () => {
     const result = await replay("preToolUse", {
       tool_name: "Bash",

--- a/src/dispatch/execute.test.ts
+++ b/src/dispatch/execute.test.ts
@@ -364,7 +364,11 @@ describe("dispatch execute integration", () => {
           tool_input: { file_path: "/repo/.agents/skills/push/SKILL.md", content: "# Push\n" },
         },
         {
-          tool_name: "functions.apply_patch",
+          tool_name: "Edit",
+          toolInput: { filePath: "/repo/.codex/skills/commit/SKILL.md" },
+        },
+        {
+          tool_name: "apply_patch",
           tool_input: {
             command: [
               "*** Begin Patch",
@@ -414,6 +418,7 @@ describe("dispatch execute integration", () => {
       }
       const payloads = [
         { tool_name: "Edit", tool_input: { file_path: "/repo/src/main.ts" } },
+        { tool_name: "apply_patch", tool_input: { command: "no extractable patch target" } },
         {
           tool_name: "apply_patch",
           tool_input: {

--- a/src/dispatch/preToolUseStrategy.ts
+++ b/src/dispatch/preToolUseStrategy.ts
@@ -91,11 +91,53 @@ function classifyAllowHint(
 /** Deny reason from any of the shapes hooks use for PreToolUse denials. */
 function extractDenyReason(resp: Record<string, any>): string | null {
   const hso = getHookSpecificOutput(resp)
-  const candidates = [hso?.permissionDecisionReason, resp.reason, resp.stopReason]
+  const candidates = [
+    hso?.permissionDecisionReason,
+    resp.reason,
+    resp.stopReason,
+    resp.systemMessage,
+    hso?.additionalContext,
+  ]
   for (const candidate of candidates) {
     if (typeof candidate === "string" && candidate.trim()) return candidate.trim()
   }
   return null
+}
+
+function hasTopLevelReason(resp: Record<string, any>): boolean {
+  return typeof resp.reason === "string" && !!resp.reason.trim()
+}
+
+function hasCanonicalDenyReason(hso: Record<string, any> | undefined, reason: string): boolean {
+  return hso?.permissionDecision === "deny" && hso.permissionDecisionReason === reason
+}
+
+/**
+ * Ensure every accepted PreToolUse deny shape has an agent-visible reason.
+ * Existing reasons remain byte-for-byte unchanged; only incomplete legacy or
+ * external outputs receive the deterministic hook-naming fallback.
+ */
+export function normalizePreToolDenyReason(
+  resp: Record<string, any>,
+  hookFile: string
+): string | null {
+  if (!isDeny(resp)) return null
+
+  const hso = getHookSpecificOutput(resp)
+  const existing = extractDenyReason(resp)
+  const reason =
+    existing ??
+    `Blocked by ${hookFile}. The hook supplied no retry guidance; resolve this hook's requirement before retrying.`
+
+  if (!existing) {
+    resp.reason = reason
+    resp.systemMessage = reason
+    if (hso?.permissionDecision === "deny") hso.permissionDecisionReason = reason
+  } else if (!hasTopLevelReason(resp) && !hasCanonicalDenyReason(hso, reason)) {
+    resp.reason = reason
+  }
+
+  return reason
 }
 
 /**
@@ -157,7 +199,7 @@ function downgradesDeny(mode: FileEditDenyDowngrade, hookFile: string): boolean 
   return false
 }
 
-function collectPreToolResults(
+export function collectPreToolResults(
   results: Array<{ execution: HookExecution; parsed: Record<string, any> | null }>,
   executions: HookExecution[],
   acc: PreToolAccumulator
@@ -168,6 +210,7 @@ function collectPreToolResults(
       executions.push(execution)
       continue
     }
+    if (resp) normalizePreToolDenyReason(resp, execution.file)
     if (resp && isDeny(resp) && downgradesDeny(downgradeMode, execution.file)) {
       execution.status = "allow-with-reason"
       const reason = extractDenyReason(resp)

--- a/src/dispatch/strategies.test.ts
+++ b/src/dispatch/strategies.test.ts
@@ -117,6 +117,48 @@ describe("collectPreToolResults denial handling", () => {
     expect(contexts[0]).toContain("pretooluse-edit-guard.ts")
     expect(finalResponse).toEqual({})
   })
+
+  it("collects later hints and passes after downgrading a deny", () => {
+    const denied = makeHookExecution("pretooluse-edit-guard.ts")
+    const hinted = makeHookExecution("pretooluse-hint.ts")
+    const passing = makeHookExecution("pretooluse-pass.ts")
+    const executions: HookExecution[] = []
+    const hints: string[] = []
+    const contexts: string[] = []
+    const finalResponse: Record<string, any> = {}
+
+    collectPreToolResults(
+      [
+        {
+          execution: denied,
+          parsed: { decision: "deny", reason: "Create a task before editing." },
+        },
+        {
+          execution: hinted,
+          parsed: {
+            hookSpecificOutput: {
+              hookEventName: "PreToolUse",
+              permissionDecision: "allow",
+              permissionDecisionReason: "Keep the change focused.",
+            },
+          },
+        },
+        { execution: passing, parsed: null },
+      ],
+      executions,
+      { hints, contexts, downgradeMode: "skill-active", finalResponse }
+    )
+
+    expect(executions).toEqual([denied, hinted, passing])
+    expect(executions.map((execution) => execution.status)).toEqual([
+      "allow-with-reason",
+      "allow-with-reason",
+      "ok",
+    ])
+    expect(contexts).toEqual(["Create a task before editing."])
+    expect(hints).toEqual(["Keep the change focused."])
+    expect(finalResponse).toEqual({})
+  })
 })
 
 /** Capture everything writeResponse emits to stdout for a single call. */

--- a/src/dispatch/strategies.test.ts
+++ b/src/dispatch/strategies.test.ts
@@ -12,11 +12,112 @@ import type { HookExecution } from "./engine.ts"
 import { writeResponse } from "./engine.ts"
 import {
   applyPreToolHumanisedContext,
+  collectPreToolResults,
   isSkillGateHook,
+  normalizePreToolDenyReason,
   preparePreToolHints,
   resolveFileEditDenyDowngrade,
   shouldDowngradeFileEditDenies,
 } from "./preToolUseStrategy.ts"
+
+describe("normalizePreToolDenyReason", () => {
+  it.each([
+    { decision: "deny" },
+    { decision: "block" },
+    { continue: false },
+    { hookSpecificOutput: { decision: "deny" } },
+    { hookSpecificOutput: { decision: "block" } },
+    {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+      },
+    },
+  ])("adds a hook-naming fallback for a reasonless deny shape", (response) => {
+    const output: Record<string, any> = response
+    const reason = normalizePreToolDenyReason(output, "pretooluse-example.ts")
+    expect(reason).toContain("pretooluse-example.ts")
+    expect(reason).toContain("resolve this hook's requirement before retrying")
+    expect(output.reason).toBe(reason)
+  })
+
+  it("promotes systemMessage retry guidance without rewriting it", () => {
+    const response: Record<string, any> = {
+      decision: "block",
+      systemMessage: "Retry after TaskList has refreshed the task state.",
+    }
+    expect(normalizePreToolDenyReason(response, "pretooluse-task-state.ts")).toBe(
+      response.systemMessage
+    )
+    expect(response.reason).toBe(response.systemMessage)
+  })
+
+  it("leaves canonical builder output unchanged", () => {
+    const response = {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Run the required skill.",
+      },
+    }
+    const before = structuredClone(response)
+    expect(normalizePreToolDenyReason(response, "pretooluse-skill-gate.ts")).toBe(
+      "Run the required skill."
+    )
+    expect(response).toEqual(before)
+  })
+
+  it("ignores non-deny responses", () => {
+    const response = { decision: "allow" }
+    expect(normalizePreToolDenyReason(response, "pretooluse-example.ts")).toBeNull()
+    expect(response).toEqual({ decision: "allow" })
+  })
+})
+
+describe("collectPreToolResults denial handling", () => {
+  it("normalizes and short-circuits on the first surviving generic deny", () => {
+    const first = makeHookExecution("pretooluse-first.ts")
+    const second = makeHookExecution("pretooluse-second.ts")
+    const executions: HookExecution[] = []
+    const finalResponse: Record<string, any> = {}
+
+    collectPreToolResults(
+      [
+        { execution: first, parsed: { continue: false } },
+        { execution: second, parsed: { decision: "block", reason: "later deny" } },
+      ],
+      executions,
+      { hints: [], contexts: [], downgradeMode: null, finalResponse }
+    )
+
+    expect(executions).toEqual([first])
+    expect(first.status).toBe("deny")
+    expect(finalResponse.reason).toContain("pretooluse-first.ts")
+    expect(finalResponse.reason).not.toContain("later deny")
+  })
+
+  it("turns a reasonless deny into named advisory context when downgraded", () => {
+    const denied = makeHookExecution("pretooluse-edit-guard.ts")
+    const passing = makeHookExecution("pretooluse-pass.ts")
+    const executions: HookExecution[] = []
+    const contexts: string[] = []
+    const finalResponse: Record<string, any> = {}
+
+    collectPreToolResults(
+      [
+        { execution: denied, parsed: { decision: "deny" } },
+        { execution: passing, parsed: {} },
+      ],
+      executions,
+      { hints: [], contexts, downgradeMode: "skill-active", finalResponse }
+    )
+
+    expect(executions).toEqual([denied, passing])
+    expect(denied.status).toBe("allow-with-reason")
+    expect(contexts[0]).toContain("pretooluse-edit-guard.ts")
+    expect(finalResponse).toEqual({})
+  })
+})
 
 /** Capture everything writeResponse emits to stdout for a single call. */
 function captureWriteResponse(response: Record<string, any>): string {

--- a/src/infractions.test.ts
+++ b/src/infractions.test.ts
@@ -7,6 +7,7 @@ import {
   complianceBaselineWantedLevel,
   DENY_FOOTER_MARKERS,
   evaluateInfraction,
+  INFRACTION_DENIAL_MARKER,
   INFRACTION_WINDOW_MS,
   lastSettledAttempt,
   resolveCurrentAttempt,
@@ -58,6 +59,17 @@ function deniedBashAttempt(id: string, command: string, ts?: string): string[] {
     toolResultLine({
       toolUseId: id,
       text: `Blocked: do the thing.\n\n${DENY_FOOTER}`,
+      timestamp: ts,
+    }),
+  ]
+}
+
+function infractionDeniedBashAttempt(id: string, command: string, ts?: string): string[] {
+  return [
+    toolUseLine({ id, name: "Bash", input: { command }, timestamp: ts }),
+    toolResultLine({
+      toolUseId: id,
+      text: `Blocked by ${INFRACTION_DENIAL_MARKER}.\n\n${DENY_FOOTER}`,
       timestamp: ts,
     }),
   ]
@@ -116,9 +128,16 @@ describe("collectBlockedAttempts", () => {
 function bk(
   key: string,
   timestampMs: number | null,
-  isCooldown = false
-): { toolName: string; key: string; timestampMs: number | null; isCooldown: boolean } {
-  return { toolName: "Bash", key, timestampMs, isCooldown }
+  isCooldown = false,
+  isInfractionDenial = false
+): {
+  toolName: string
+  key: string
+  timestampMs: number | null
+  isCooldown: boolean
+  isInfractionDenial: boolean
+} {
+  return { toolName: "Bash", key, timestampMs, isCooldown, isInfractionDenial }
 }
 
 describe("assessInfraction", () => {
@@ -155,9 +174,24 @@ describe("assessInfraction", () => {
     expect(assessInfraction(current, blocked, now).level).toBe("yellow")
   })
 
+  it("does not count the detector's own denial against the same retry budget", () => {
+    const now = Date.now()
+    const current = { toolName: "Bash", key: "git push" }
+    const blocked = [bk("git push", now - 1000), bk("git push", now - 500, false, true)]
+    expect(assessInfraction(current, blocked, now).level).toBe("yellow")
+  })
+
   it("does not count denials of a different action", () => {
     const current = { toolName: "Bash", key: "git push" }
-    const blocked = [{ toolName: "Edit", key: "/x.ts", timestampMs: Date.now(), isCooldown: false }]
+    const blocked = [
+      {
+        toolName: "Edit",
+        key: "/x.ts",
+        timestampMs: Date.now(),
+        isCooldown: false,
+        isInfractionDenial: false,
+      },
+    ]
     expect(assessInfraction(current, blocked).level).toBe("none")
   })
 
@@ -298,6 +332,17 @@ describe("evaluateInfraction — cooldown + de-escalation", () => {
       ...deniedBashAttempt("c", "git push", ETS),
     ]
     expect(evaluateInfraction(lines, bash("git push"), ENOW).level).toBe("red")
+  })
+
+  it("does not worsen the retry count when the preceding red denial came from this detector", () => {
+    const lines = [
+      ...deniedBashAttempt("a", "git push", ETS),
+      ...deniedBashAttempt("b", "git push", ETS),
+      ...infractionDeniedBashAttempt("c", "git push", ETS),
+    ]
+    const out = evaluateInfraction(lines, bash("git push"), ENOW)
+    expect(out.level).toBe("red")
+    expect(out.priorDenialCount).toBe(2)
   })
 
   it("passes yellow through when the current call is a first retry", () => {

--- a/src/infractions.ts
+++ b/src/infractions.ts
@@ -40,6 +40,9 @@ export const INFRACTION_WINDOW_MS = 20 * 60 * 1000
  */
 export const COOLDOWN_MARKER = "cooling off after a hard block"
 
+/** Stable marker for a denial emitted by the retry-after-block detector itself. */
+export const INFRACTION_DENIAL_MARKER = "retry-after-block enforcement"
+
 /**
  * Wanted level, GTA-style: rises with repeated bad behaviour, falls with good.
  *   - none     → ☆0  clear
@@ -73,6 +76,8 @@ interface ToolResultRecord {
   denied: boolean
   /** True when this denial was our own cooldown hold (carries COOLDOWN_MARKER). */
   isCooldown: boolean
+  /** True when the retry-after-block detector itself emitted the denial. */
+  isInfractionDenial: boolean
 }
 
 /** A tool_use whose result was a denial, reduced to a comparable key. */
@@ -82,6 +87,8 @@ interface BlockedAttempt {
   timestampMs: number | null
   /** True when the denial was our cooldown hold, not a real block. */
   isCooldown: boolean
+  /** True when the retry-after-block detector itself emitted the denial. */
+  isInfractionDenial: boolean
 }
 
 /** The most recent tool call that has a settled result, with how it resolved. */
@@ -187,6 +194,7 @@ function collectResults(lines: string[]): Map<string, ToolResultRecord> {
         timestampMs: parseTimestampMs(block.timestamp) ?? entryTimestampMs,
         denied: isDenialText(text),
         isCooldown: text.includes(COOLDOWN_MARKER),
+        isInfractionDenial: text.includes(INFRACTION_DENIAL_MARKER),
       })
     }
   }
@@ -210,6 +218,7 @@ function blockedAttemptFromBlock(
     key,
     timestampMs: result.timestampMs ?? entryTimestampMs,
     isCooldown: result.isCooldown,
+    isInfractionDenial: result.isInfractionDenial,
   }
 }
 
@@ -277,6 +286,7 @@ export function assessInfraction(
   const priorDenialCount = blockedAttempts.filter(
     (attempt) =>
       !attempt.isCooldown &&
+      !attempt.isInfractionDenial &&
       attempt.key === current.key &&
       (attempt.timestampMs === null || nowMs - attempt.timestampMs <= windowMs)
   ).length
@@ -299,6 +309,7 @@ function denialCountForKey(
   return blockedAttempts.filter(
     (attempt) =>
       !attempt.isCooldown &&
+      !attempt.isInfractionDenial &&
       attempt.key === key &&
       (attempt.timestampMs === null || nowMs - attempt.timestampMs <= windowMs)
   ).length

--- a/src/issue-store.ts
+++ b/src/issue-store.ts
@@ -1136,6 +1136,11 @@ export class IssueStore {
       .run(repo, kind, value, Date.now())
   }
 
+  /** Delete one per-repo sync cursor without clearing the repo's other cached state. */
+  deleteSyncCursor(repo: string, kind: string): void {
+    this.db.query("DELETE FROM sync_cursors WHERE repo = ? AND kind = ?").run(repo, kind)
+  }
+
   /** Return all repos that have a stored `cwd`, so the daemon can re-register them for sync on startup. */
   listKnownRepoCwds(): { repo: string; cwd: string }[] {
     return this.db

--- a/src/tool-matchers.test.ts
+++ b/src/tool-matchers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { isSkillMdOnlyFileEditPayload } from "./tool-matchers.ts"
+
+describe("isSkillMdOnlyFileEditPayload", () => {
+  test("accepts camelCase inputs and plain apply_patch SKILL.md targets", () => {
+    expect(
+      isSkillMdOnlyFileEditPayload("Edit", {
+        toolInput: { filePath: "/repo/.codex/skills/commit/SKILL.md" },
+      })
+    ).toBeTrue()
+    expect(
+      isSkillMdOnlyFileEditPayload("apply_patch", {
+        tool_input: {
+          command: "*** Begin Patch\n*** Update File: .agents/skills/push/SKILL.md\n*** End Patch",
+        },
+      })
+    ).toBeTrue()
+  })
+
+  test("rejects missing and mixed target paths", () => {
+    expect(
+      isSkillMdOnlyFileEditPayload("apply_patch", { tool_input: { command: "no targets" } })
+    ).toBeFalse()
+    expect(
+      isSkillMdOnlyFileEditPayload("apply_patch", {
+        tool_input: {
+          command: [
+            "*** Begin Patch",
+            "*** Update File: .codex/skills/commit/SKILL.md",
+            "*** Update File: src/main.ts",
+            "*** End Patch",
+          ].join("\n"),
+        },
+      })
+    ).toBeFalse()
+  })
+})


### PR DESCRIPTION
## Summary
- ensure every PreToolUse denial carries actionable agent-visible guidance
- prevent timed-out upstream sync overlap and prune stale restore cursors
- scope daemon snapshot eviction to exact project boundaries
- extend SKILL.md bypass and deny-downgrade regression coverage
- enable the stop-contract test gate and avoid retry-detector self-counting

## Testing
- `bun test --reporter=dots --parallel=4`
- `bun run typecheck`
- `bun run lint` (0 errors; 228 existing warnings)
- pre-push targeted suite: 392 pass, 0 fail

## Risk / Rollout
- Low-to-moderate: dispatch denial normalization and daemon lifecycle behavior are covered by focused and integration tests.
- Restarted the local daemon after runtime changes and confirmed healthy status.

Closes #719
Closes #720
Closes #724
Closes #725
Closes #728
Closes #735