### PR TITLE
fix(hooks): allow Codex home access

### DIFF
--- a/hooks/pretooluse-protect-sandbox.test.ts
+++ b/hooks/pretooluse-protect-sandbox.test.ts
@@ -16,7 +16,7 @@ const TEST_HOME = homedir()
 
 async function runPinnedHomeBashHook(
   command: string,
-  opts: { cwd?: string } = {}
+  opts: { agent?: "codex"; cwd?: string } = {}
 ): Promise<{ decision?: string; stdout: string }> {
   const proc = Bun.spawn(["bun", resolve(process.cwd(), HOOK)], {
     stdin: "pipe",
@@ -27,6 +27,7 @@ async function runPinnedHomeBashHook(
   })
   await proc.stdin.write(
     JSON.stringify({
+      ...(opts.agent ? { _agent: opts.agent } : {}),
       tool_name: "Bash",
       tool_input: { command },
     })
@@ -178,6 +179,28 @@ describe("pretooluse-protect-sandbox (shell commands)", () => {
     const result = await runPinnedHomeBashHook(
       `node -e "const fs=require('fs'),path=require('path'),os=require('os');const dir=path.join(os.homedir(),'.Codex','tasks');console.log(fs.readdirSync(dir));"`
     )
+    expect(result.decision).toBe("deny")
+  })
+
+  test("allows Codex shell commands to write within ~/.codex", async () => {
+    const result = await runPinnedHomeBashHook(
+      `bun -e "await Bun.write('${join(TEST_HOME, ".codex", "config.toml")}', '')"`,
+      { agent: "codex" }
+    )
+    expect(result.decision).toBeUndefined()
+  })
+
+  test("still blocks non-Codex shell commands that write within ~/.codex", async () => {
+    const result = await runPinnedHomeBashHook(
+      `bun -e "await Bun.write('${join(TEST_HOME, ".codex", "config.toml")}', '')"`
+    )
+    expect(result.decision).toBe("deny")
+  })
+
+  test("still blocks Codex shell commands that directly access task storage", async () => {
+    const result = await runPinnedHomeBashHook("cat ~/.codex/tasks/session/1.json", {
+      agent: "codex",
+    })
     expect(result.decision).toBe("deny")
   })
 

--- a/hooks/pretooluse-protect-sandbox.ts
+++ b/hooks/pretooluse-protect-sandbox.ts
@@ -12,12 +12,14 @@
 
 import { homedir } from "node:os"
 import { isAbsolute, join, resolve } from "node:path"
+import { detectCurrentAgentFromHookPayload } from "../src/agent-paths.ts"
 import { runSwizHookAsMain, type SwizToolHook } from "../src/SwizHook.ts"
 import { isFileEditTool, isShellTool } from "../src/tool-matchers.ts"
 import { preToolUseAllowWithContext, preToolUseDeny } from "../src/utils/hook-utils.ts"
 import { buildIssueGuidance, isSettingDisableCommand } from "../src/utils/inline-hook-helpers.ts"
 import {
   buildProtectedTaskStorageDenyReason,
+  isCodexHomePath,
   isHiddenTopLevelHomePath,
   isProtectedTaskStoragePath,
   isSafeReadOnlyShellCommand,
@@ -135,13 +137,15 @@ async function normalizeShellPath(
 async function isHiddenHomePathInCommand(
   rawPath: string,
   cwd: string,
-  homeDir: string
+  homeDir: string,
+  allowCodexHome: boolean
 ): Promise<boolean> {
   const resolved = await normalizeShellPath(rawPath, cwd, homeDir)
   if (!resolved) return false
   // The session's own persisted tool-result/output files live under a hidden
   // home dir but are the agent's own working data — never block reading them.
   if (isSessionToolResultsPath(resolved)) return false
+  if (allowCodexHome && isCodexHomePath(resolved, homeDir)) return false
   if (!isHiddenTopLevelHomePath(resolved, homeDir)) return false
 
   const normalizedCwd = cwd.replace(/\\/g, "/")
@@ -154,7 +158,8 @@ async function isHiddenHomePathInCommand(
 
 async function shouldBlockShellCommand(
   command: string,
-  cwd: string
+  cwd: string,
+  allowCodexHome: boolean
 ): Promise<BlockedShellPath | null> {
   const homeDir = homedir()
   if (!homeDir || !command) return null
@@ -194,13 +199,20 @@ async function shouldBlockShellCommand(
       if (resolvedCandidate && isProtectedTaskStoragePath(resolvedCandidate)) {
         return { kind: "task-storage", path: resolvedCandidate }
       }
-      if (await isHiddenHomePathInCommand(candidate, canonicalCwd, canonicalHomeDir)) {
+      if (
+        await isHiddenHomePathInCommand(candidate, canonicalCwd, canonicalHomeDir, allowCodexHome)
+      ) {
         return { kind: "hidden-home", path: candidate }
       }
       if (
         hasHomeReference &&
         hasPathBuilder &&
-        (await isHiddenHomePathInCommand(candidate, canonicalHomeDir, canonicalHomeDir))
+        (await isHiddenHomePathInCommand(
+          candidate,
+          canonicalHomeDir,
+          canonicalHomeDir,
+          allowCodexHome
+        ))
       ) {
         return { kind: "hidden-home", path: candidate }
       }
@@ -254,6 +266,7 @@ const pretoolUseProtectSandbox: SwizToolHook = {
     const input = rawInput as Record<string, any>
     const toolName: string = (input.tool_name as string) ?? ""
     const toolInput = input.tool_input as Record<string, string> | undefined
+    const allowCodexHome = detectCurrentAgentFromHookPayload(input)?.id === "codex"
 
     if (isShellTool(toolName)) {
       const command: string = (toolInput?.command ?? "").normalize("NFKC")
@@ -279,7 +292,11 @@ const pretoolUseProtectSandbox: SwizToolHook = {
         )
       }
 
-      const blocked = await shouldBlockShellCommand(command, input.cwd ?? process.cwd())
+      const blocked = await shouldBlockShellCommand(
+        command,
+        input.cwd ?? process.cwd(),
+        allowCodexHome
+      )
       if (blocked) {
         if (blocked.kind === "task-storage") {
           return preToolUseDeny(buildProtectedTaskStorageDenyReason(blocked.path))

--- a/hooks/pretooluse-sandboxed-edits.test.ts
+++ b/hooks/pretooluse-sandboxed-edits.test.ts
@@ -73,9 +73,10 @@ async function runHook(
   toolName: string,
   filePath: string,
   {
+    agent,
     sandboxedEdits = true,
     fakeHomeOverride,
-  }: { sandboxedEdits?: boolean; fakeHomeOverride?: string } = {}
+  }: { agent?: "codex"; sandboxedEdits?: boolean; fakeHomeOverride?: string } = {}
 ): Promise<HookResult> {
   // Build an env with a fake HOME so we can control whether sandboxedEdits is on/off.
   // readSwizSettings() reads from HOME/.swiz/settings.json.
@@ -90,6 +91,7 @@ async function runHook(
   }
 
   const payload = {
+    ...(agent ? { _agent: agent } : {}),
     tool_name: toolName,
     cwd,
     tool_input: { file_path: filePath },
@@ -192,6 +194,42 @@ describe("pretooluse-sandboxed-edits", () => {
     expect(msg).toContain("Hidden home-directory edits are blocked")
     expect(msg).toContain("read-only shell command")
     expect(msg).not.toContain("/update-memory")
+  })
+
+  test("allows Codex edits within ~/.codex", async () => {
+    const cwd = await createTempDir()
+    const fakeHome = await createTempDir()
+    const configPath = join(fakeHome, ".codex", "config.toml")
+    const result = await runHook(cwd, "Write", configPath, {
+      agent: "codex",
+      fakeHomeOverride: fakeHome,
+    })
+    expect(result.exitCode).toBe(0)
+    const hso = result.json?.hookSpecificOutput as Record<string, any> | undefined
+    expect(hso?.permissionDecision).toBe("allow")
+  })
+
+  test("still blocks non-Codex edits within ~/.codex", async () => {
+    const cwd = await createTempDir()
+    const fakeHome = await createTempDir()
+    const configPath = join(fakeHome, ".codex", "config.toml")
+    const result = await runHook(cwd, "Write", configPath, { fakeHomeOverride: fakeHome })
+    expect(result.exitCode).toBe(0)
+    const hso = result.json?.hookSpecificOutput as Record<string, any> | undefined
+    expect(hso?.permissionDecision).toBe("deny")
+  })
+
+  test("still blocks Codex edits to task storage", async () => {
+    const cwd = await createTempDir()
+    const fakeHome = await createTempDir()
+    const taskPath = join(fakeHome, ".codex", "tasks", "session", "1.json")
+    const result = await runHook(cwd, "Write", taskPath, {
+      agent: "codex",
+      fakeHomeOverride: fakeHome,
+    })
+    expect(result.exitCode).toBe(0)
+    const hso = result.json?.hookSpecificOutput as Record<string, any> | undefined
+    expect(hso?.permissionDecision).toBe("deny")
   })
 
   test("allows hidden home-directory edits when dispatch is inside that hidden root", async () => {

--- a/hooks/pretooluse-sandboxed-edits.ts
+++ b/hooks/pretooluse-sandboxed-edits.ts
@@ -8,6 +8,7 @@
 
 import { tmpdir } from "node:os"
 import { dirname } from "node:path"
+import { detectCurrentAgentFromHookPayload } from "../src/agent-paths.ts"
 import { git, isGitHubHost, isGitRepo, parseRemoteUrl } from "../src/git-helpers.ts"
 import { getHomeDirOrNull } from "../src/home.ts"
 import { runSwizHookAsMain, type SwizFileEditHook, type SwizHookOutput } from "../src/SwizHook.ts"
@@ -28,6 +29,7 @@ const AUTO_MEMORY_PATH_RE = /[/\\]\.claude[/\\]projects[/\\][^/\\]+[/\\]memory[/
 import { buildIssueGuidance } from "../src/utils/inline-hook-helpers.ts"
 import {
   buildProtectedTaskStorageDenyReason,
+  isCodexHomePath,
   isHiddenTopLevelHomePath,
   isProtectedTaskStoragePath,
   resolveCanonical,
@@ -211,6 +213,7 @@ const pretooluseSandboxedEdits: SwizFileEditHook = {
 
   async run(input): Promise<SwizHookOutput> {
     const parsed = fileEditHookInputSchema.parse(input)
+    const allowCodexHome = detectCurrentAgentFromHookPayload(parsed)?.id === "codex"
 
     if (!isFileEditTool(parsed.tool_name ?? "")) return preToolUseAllow("")
 
@@ -242,7 +245,19 @@ const pretooluseSandboxedEdits: SwizFileEditHook = {
     // operates in a uniform canonical namespace — no mix of logical and real paths.
     const cwd = await resolveCanonical(hookCwd)
 
-    // 3a. Auto-memory writes are always allowed — outside cwd but owned by the agent.
+    // 3a. Codex owns its home directory and may update its configuration and skills.
+    const homeDir = getHomeDirOrNull()
+    if (allowCodexHome && homeDir) {
+      const canonicalHome = await resolveCanonical(homeDir)
+      if (isCodexHomePath(target, canonicalHome)) {
+        return preToolUseAllowWithContext(
+          "Codex home-directory edit allowed: within ~/.codex.",
+          SAFE_READ_ONLY_INSPECTION_HINT
+        )
+      }
+    }
+
+    // 3b. Auto-memory writes are always allowed — outside cwd but owned by the agent.
     if (AUTO_MEMORY_PATH_RE.test(target.replace(/\\/g, "/"))) {
       return preToolUseAllowWithContext(
         "Auto-memory write allowed: within agent memory directory.",

--- a/hooks/sandbox-path-utils.ts
+++ b/hooks/sandbox-path-utils.ts
@@ -189,3 +189,10 @@ export function isHiddenTopLevelHomePath(target: string, homeDir: string): boole
   const firstSegment = relative.split("/")[0] ?? ""
   return firstSegment.startsWith(".")
 }
+
+export function isCodexHomePath(target: string, homeDir: string): boolean {
+  const normalizedTarget = target.replace(/\\/g, "/")
+  const normalizedHome = homeDir.replace(/\\/g, "/").replace(/\/$/, "")
+  const codexRoot = `${normalizedHome}/.codex`
+  return normalizedTarget === codexRoot || normalizedTarget.startsWith(`${codexRoot}/`)
+}


### PR DESCRIPTION
## Summary

Allow Codex-originated shell commands and file edits within the canonical `~/.codex` directory without sandbox denials.

## What changed

- detect the originating agent before applying hidden-home sandbox restrictions
- exempt only Codex calls targeting canonical paths under `~/.codex`
- preserve direct-access protection for `~/.codex/tasks` and keep other agents denied
- add shell and file-edit regression coverage for each boundary

## Why

Codex needs to manage its own configuration and skills under `~/.codex`, but the generic hidden-home sandbox treated those operations as cross-sandbox access.

## Testing

- `bun test --reporter=dots --parallel=2 hooks/pretooluse-protect-sandbox.test.ts hooks/pretooluse-sandboxed-edits.test.ts` (69 passed)
- `bun run typecheck`
- `bun run lint`
- mandatory pre-commit hooks
- mandatory pre-push targeted suite (69 passed)

## Risk / Rollout

Low and scoped by both caller identity and canonical path. Symlink resolution remains in place, task storage remains protected, and non-Codex callers retain the existing denial.