### PR TITLE
perf(tests): isolate heavy hook boundaries

### DIFF
--- a/hooks/hardening-regression.test.ts
+++ b/hooks/hardening-regression.test.ts
@@ -11,7 +11,7 @@ setDefaultTimeout(30_000)
 import { writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { parse as parseYaml } from "yaml"
-import { runHook, useTempDir, writeTask } from "../src/utils/test-utils.ts"
+import { neutralAgentEnv, runHook, useTempDir, writeTask } from "../src/utils/test-utils.ts"
 
 // ─── Shared test infrastructure ─────────────────────────────────────────────
 
@@ -279,7 +279,7 @@ describe("createSessionTask input sanitization", () => {
     const proc = Bun.spawn(["bun", "-e", script], {
       stdout: "pipe",
       stderr: "pipe",
-      env: { ...process.env, HOME: "" },
+      env: neutralAgentEnv({ HOME: undefined }),
     })
     const stdout = await new Response(proc.stdout).text()
     await proc.exited

--- a/hooks/negative-path-regression.test.ts
+++ b/hooks/negative-path-regression.test.ts
@@ -18,31 +18,13 @@ import { type HookResult, runHookInProcess, useTempDir } from "../src/utils/test
 
 const { create: createTempDir } = useTempDir("swiz-negpath-")
 
-/**
- * Run a hook script as a subprocess with controlled stdin and env.
- */
+/** Run hook behavior in-process with isolated environment overrides. */
 async function runHook(
   script: string,
   stdinPayload: Record<string, any>,
   envOverrides: Record<string, string | undefined> = {}
 ): Promise<HookResult> {
-  const payload = JSON.stringify(stdinPayload)
-  const env: Record<string, string | undefined> = { ...process.env, ...envOverrides }
-
-  const proc = Bun.spawn(["bun", script], {
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-    env,
-  })
-  await proc.stdin.write(payload)
-  await proc.stdin.end()
-
-  const stdout = await new Response(proc.stdout).text()
-  const stderr = await new Response(proc.stderr).text()
-  await proc.exited
-
-  return { exitCode: proc.exitCode, stdout: stdout.trim(), stderr }
+  return await runHookInProcess(script, stdinPayload, { env: envOverrides })
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/hooks/negative-path-regression.test.ts
+++ b/hooks/negative-path-regression.test.ts
@@ -12,7 +12,12 @@ import { describe, expect, setDefaultTimeout, test } from "bun:test"
 setDefaultTimeout(30_000)
 
 import { join } from "node:path"
-import { type HookResult, runHookInProcess, useTempDir } from "../src/utils/test-utils.ts"
+import {
+  type HookResult,
+  runHookInProcess,
+  runHook as runHookWithEnvContract,
+  useTempDir,
+} from "../src/utils/test-utils.ts"
 
 // ─── Shared test infrastructure ─────────────────────────────────────────────
 
@@ -24,6 +29,11 @@ async function runHook(
   stdinPayload: Record<string, any>,
   envOverrides: Record<string, string | undefined> = {}
 ): Promise<HookResult> {
+  // A missing HOME is a process-start contract. Importing hook modules after
+  // deleting HOME makes Bun place its transpiler cache under the repository.
+  if (Object.hasOwn(envOverrides, "HOME") && envOverrides.HOME === undefined) {
+    return await runHookWithEnvContract(script, stdinPayload, envOverrides)
+  }
   return await runHookInProcess(script, stdinPayload, { env: envOverrides })
 }
 

--- a/hooks/pretooluse-block-preexisting-dismissals.test.ts
+++ b/hooks/pretooluse-block-preexisting-dismissals.test.ts
@@ -1,16 +1,6 @@
-import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
-
-// Subprocess tests need extra headroom under concurrent test suite load
-setDefaultTimeout(30_000)
-
-import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
 import { makeTranscript, type SimpleHookResult } from "../src/utils/test-utils.ts"
-
-const BUN_EXE = Bun.which("bun") ?? "bun"
-const WORKSPACE_ROOT = process.cwd()
-const HOOK_SCRIPT = join(WORKSPACE_ROOT, "hooks/pretooluse-block-preexisting-dismissals.ts")
+import { evaluatePretooluseBlockPreexistingDismissals } from "./pretooluse-block-preexisting-dismissals.ts"
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -84,62 +74,37 @@ async function runHook(opts: {
   toolName?: string
   command?: string
   transcriptContent: string
+  isGitRepo?: boolean
 }): Promise<SimpleHookResult> {
-  const tPath = join(tmpDir, `t-${Math.random().toString(36).slice(2)}.jsonl`)
-  await Bun.write(tPath, opts.transcriptContent)
-
   const toolName = opts.toolName ?? "Bash"
   const toolInput =
     toolName === "Bash"
       ? { command: opts.command ?? "echo hello" }
       : { file_path: "/tmp/test.ts", old_string: "a", new_string: "b" }
 
-  const payload = JSON.stringify({
-    tool_name: toolName,
-    tool_input: toolInput,
-    transcript_path: tPath,
-    session_id: "test",
-    cwd: tmpDir,
-  })
-
-  const proc = Bun.spawn([BUN_EXE, HOOK_SCRIPT], {
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-    cwd: WORKSPACE_ROOT,
-  })
-  await proc.stdin.write(payload)
-  await proc.stdin.end()
-  const [out] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ])
-  await proc.exited
-
-  if (!out.trim()) return { blocked: false, reason: "" }
-  const parsed = JSON.parse(out.trim())
-  const hso = parsed?.hookSpecificOutput
-  const decision = hso?.permissionDecision ?? parsed?.decision
+  const output = await evaluatePretooluseBlockPreexistingDismissals(
+    {
+      tool_name: toolName,
+      tool_input: toolInput,
+      transcript_path: "/test/transcript.jsonl",
+      session_id: "test",
+      cwd: "/test/repo",
+    },
+    {
+      runtime: {
+        isGitRepo: () => Promise.resolve(opts.isGitRepo ?? true),
+        readTranscriptLines: () => Promise.resolve(opts.transcriptContent.split("\n")),
+      },
+    }
+  )
+  const parsed = output as Record<string, any>
+  const hso = parsed.hookSpecificOutput as Record<string, any> | undefined
+  const decision = hso?.permissionDecision ?? parsed.decision
   return {
     blocked: decision === "deny",
-    reason: hso?.permissionDecisionReason ?? parsed?.reason ?? "",
+    reason: String(hso?.permissionDecisionReason ?? parsed.reason ?? ""),
   }
 }
-
-// ─── Temp dir lifecycle ──────────────────────────────────────────────────────
-
-let tmpDir: string
-
-beforeAll(async () => {
-  tmpDir = await mkdtemp(join(tmpdir(), "preexisting-dismissals-test-"))
-  // Init a git repo so isGitRepo check passes
-  const proc = Bun.spawn(["git", "init"], { cwd: tmpDir, stdout: "pipe", stderr: "pipe" })
-  await proc.exited
-})
-
-afterAll(async () => {
-  await rm(tmpDir, { recursive: true })
-})
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -405,41 +370,15 @@ describe("pretooluse-block-preexisting-dismissals", () => {
     })
 
     test("non-git directory is not blocked", async () => {
-      const nonGitDir = await mkdtemp(join(tmpdir(), "nongit-"))
-      const tPath = join(nonGitDir, "transcript.jsonl")
-      await Bun.write(
-        tPath,
-        makeTranscript(
+      const result = await runHook({
+        isGitRepo: false,
+        transcriptContent: makeTranscript(
           shellCommandEntry("bun run lint"),
           toolResultEntry("error: something failed"),
           assistantTextEntry("This is pre-existing.")
-        )
-      )
-
-      const payload = JSON.stringify({
-        tool_name: "Bash",
-        tool_input: { command: "echo hello" },
-        transcript_path: tPath,
-        session_id: "test",
-        cwd: nonGitDir,
+        ),
       })
-
-      const proc = Bun.spawn([BUN_EXE, HOOK_SCRIPT], {
-        stdin: "pipe",
-        stdout: "pipe",
-        stderr: "pipe",
-        cwd: WORKSPACE_ROOT,
-      })
-      await proc.stdin.write(payload)
-      await proc.stdin.end()
-      const [out] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ])
-      await proc.exited
-
-      expect(out.trim()).toBe("")
-      await rm(nonGitDir, { recursive: true })
+      expect(result.blocked).toBe(false)
     })
   })
 

--- a/hooks/pretooluse-block-preexisting-dismissals.ts
+++ b/hooks/pretooluse-block-preexisting-dismissals.ts
@@ -248,6 +248,21 @@ async function getAllTranscriptLines(
   return summary?.sessionLines ?? []
 }
 
+export interface PreexistingDismissalRuntime {
+  isGitRepo(cwd: string): Promise<boolean>
+  readTranscriptLines(raw: Record<string, any>, transcriptPath: string): Promise<string[]>
+}
+
+export interface PreexistingDismissalOptions {
+  /** Override repository and transcript boundaries for deterministic evaluation. */
+  runtime?: Partial<PreexistingDismissalRuntime>
+}
+
+const defaultRuntime: PreexistingDismissalRuntime = {
+  isGitRepo,
+  readTranscriptLines: getAllTranscriptLines,
+}
+
 function buildBlockMessage(state: ScanState): string {
   const diagnosticSnippet = extractDiagnosticSnippet(state.lastDiagnosticOutput)
   return (
@@ -276,23 +291,26 @@ function resolveAllowReason(state: ScanState): string | null {
 
 async function resolveTranscriptContext(
   raw: Record<string, any>,
-  input: ReturnType<typeof toolHookInputSchema.parse>
+  input: ReturnType<typeof toolHookInputSchema.parse>,
+  runtime: PreexistingDismissalRuntime
 ): Promise<string[] | null> {
   const cwd = input.cwd ?? process.cwd()
-  if (!(await isGitRepo(cwd))) return null
+  if (!(await runtime.isGitRepo(cwd))) return null
   const toolName = input.tool_name ?? ""
   if (shouldSkipTool(toolName, input.tool_input ?? {})) return null
-  const lines = await getAllTranscriptLines(raw, input.transcript_path ?? "")
+  const lines = await runtime.readTranscriptLines(raw, input.transcript_path ?? "")
   return lines.length > 0 ? lines : null
 }
 
 export async function evaluatePretooluseBlockPreexistingDismissals(
-  input: unknown
+  input: unknown,
+  options: PreexistingDismissalOptions = {}
 ): Promise<SwizHookOutput> {
+  const runtime = { ...defaultRuntime, ...options.runtime }
   const raw = input as Record<string, any>
   const parsed = toolHookInputSchema.parse(raw)
 
-  const lines = await resolveTranscriptContext(raw, parsed)
+  const lines = await resolveTranscriptContext(raw, parsed, runtime)
   if (!lines) return {}
 
   const state = scanTranscript(lines)

--- a/hooks/pretooluse-git-index-lock.test.ts
+++ b/hooks/pretooluse-git-index-lock.test.ts
@@ -1,293 +1,361 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test"
-import { mkdirSync, realpathSync } from "node:fs"
-import { tmpdir } from "node:os"
+import { describe, expect, test } from "bun:test"
+import { mkdir } from "node:fs/promises"
 import { join } from "node:path"
-import { GIT_INDEX_LOCK, joinGitPath } from "../src/git-helpers.ts"
-import { neutralAgentEnv } from "../src/utils/test-utils.ts"
-import { evaluatePretooluseGitIndexLock } from "./pretooluse-git-index-lock.ts"
+import { GIT_INDEX_LOCK } from "../src/git-helpers.ts"
+import { runGit, useTempDir } from "../src/utils/test-utils.ts"
+import {
+  evaluatePretooluseGitIndexLock,
+  type GitIndexLockRuntime,
+  inspectGitProcessesForRepo,
+} from "./pretooluse-git-index-lock.ts"
 
-// Create isolated temp git repos for testing.
-// Use realpathSync after creation to resolve macOS /var → /private/var symlink
-// so paths match what `git rev-parse --show-toplevel` returns in the hook subprocess.
-let TMP = ""
-let REPO_WITHOUT_LOCK = ""
+const REPO_ROOT = "/repo"
+const GIT_DIR = `${REPO_ROOT}/.git`
 
-/** Create a fresh git repo with a lock file, returning the resolved path. */
-async function createLockedRepo(name: string): Promise<string> {
-  const rawDir = join(TMP, name)
-  mkdirSync(rawDir, { recursive: true })
-  await runCommandOutput(["git", "init"], rawDir)
-  const resolved = realpathSync(rawDir)
-  await Bun.write(joinGitPath(resolved, GIT_INDEX_LOCK), "")
-  return resolved
+interface HarnessOptions {
+  activeGit?: boolean
+  lockExists?: boolean
+  lockOld?: boolean
+  disappearAfterValidation?: boolean
+  unlinkFailures?: number
+  unlinkAlwaysFails?: boolean
+  processInspectionTimesOut?: boolean
 }
 
-async function runCommandOutput(args: string[], cwd: string): Promise<string> {
-  const proc = Bun.spawn(args, {
-    cwd,
-    stdout: "pipe",
-    stderr: "pipe",
-    env: neutralAgentEnv(),
-  })
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ])
-  await proc.exited
-  if (proc.exitCode !== 0) {
-    throw new Error(`${args.join(" ")} failed: ${stderr}`)
+interface Harness {
+  runtime: GitIndexLockRuntime
+  gitCalls: string[][]
+  processCalls: string[][]
+  lockExists(): boolean
+  unlinkCalls(): number
+}
+
+function processResult(stdout: string, options: { exitCode?: number; timedOut?: boolean } = {}) {
+  return {
+    stdout,
+    stderr: "",
+    exitCode: options.exitCode ?? 0,
+    timedOut: options.timedOut ?? false,
   }
-  return stdout.trim()
 }
 
-async function createLockedWorktree(name: string): Promise<{ worktree: string; lockPath: string }> {
-  const mainRaw = join(TMP, `${name}-main`)
-  const worktreeRaw = join(TMP, `${name}-worktree`)
-  mkdirSync(mainRaw, { recursive: true })
-  await runCommandOutput(["git", "init"], mainRaw)
-  await runCommandOutput(
-    [
-      "git",
-      "-c",
-      "user.name=Swiz Test",
-      "-c",
-      "user.email=swiz-test@example.invalid",
-      "commit",
-      "--allow-empty",
-      "-m",
-      "init",
-    ],
-    mainRaw
-  )
-  await runCommandOutput(["git", "worktree", "add", worktreeRaw], mainRaw)
+function createHarness(options: HarnessOptions = {}): Harness {
+  let now = 1_000
+  let lockExists = options.lockExists ?? true
+  let fileExistsCalls = 0
+  let unlinkCalls = 0
+  const gitCalls: string[][] = []
+  const processCalls: string[][] = []
 
-  const worktree = realpathSync(worktreeRaw)
-  const gitDir = await runCommandOutput(["git", "rev-parse", "--absolute-git-dir"], worktree)
-  const lockPath = join(gitDir, GIT_INDEX_LOCK)
-  await Bun.write(lockPath, "")
-  return { worktree, lockPath }
-}
-
-beforeAll(async () => {
-  const rawTmp = join(tmpdir(), `swiz-git-lock-test-${process.pid}`)
-  const rawClean = join(rawTmp, "repo-clean")
-  mkdirSync(rawClean, { recursive: true })
-  await runCommandOutput(["git", "init"], rawClean)
-  TMP = realpathSync(rawTmp)
-  REPO_WITHOUT_LOCK = realpathSync(rawClean)
-})
-
-afterAll(async () => {
-  if (TMP) {
-    // Clear immutable flags before cleanup to avoid EPERM.
-    try {
-      await Bun.spawn(["chflags", "-R", "nouchg", TMP]).exited
-    } catch {
-      // ignore if no immutable files exist
-    }
-    try {
-      await Bun.file(TMP).delete()
-    } catch {
-      // best-effort cleanup
-    }
+  const runtime: GitIndexLockRuntime = {
+    git(args) {
+      gitCalls.push(args)
+      if (args[1] === "--show-toplevel") return Promise.resolve(REPO_ROOT)
+      if (args[1] === "--absolute-git-dir") return Promise.resolve(GIT_DIR)
+      return Promise.resolve("")
+    },
+    fileExists() {
+      fileExistsCalls++
+      if (options.disappearAfterValidation && fileExistsCalls >= 2) {
+        lockExists = false
+      }
+      return Promise.resolve(lockExists)
+    },
+    unlink() {
+      unlinkCalls++
+      if (options.unlinkAlwaysFails || unlinkCalls <= (options.unlinkFailures ?? 0)) {
+        throw new Error("synthetic unlink failure")
+      }
+      lockExists = false
+      return Promise.resolve()
+    },
+    fileMtimeMs() {
+      return Promise.resolve(options.lockOld ? now - 20_000 : now)
+    },
+    spawn(cmd) {
+      processCalls.push(cmd)
+      if (options.processInspectionTimesOut) {
+        now += 100
+        return Promise.resolve(processResult("", { timedOut: true }))
+      }
+      if (cmd[0] === "pgrep") {
+        return Promise.resolve(
+          options.activeGit ? processResult("200") : processResult("", { exitCode: 1 })
+        )
+      }
+      if (cmd[0] === "ps") {
+        return Promise.resolve(processResult("PID PPID\n200 1\n100 50\n50 1"))
+      }
+      if (cmd[0] === "lsof") {
+        return Promise.resolve(
+          processResult(options.activeGit ? `p200\nn${REPO_ROOT}` : "p200\nn/other")
+        )
+      }
+      throw new Error(`Unexpected process command: ${cmd.join(" ")}`)
+    },
+    sleep(ms) {
+      now += ms
+      return Promise.resolve()
+    },
+    now: () => now,
+    pid: () => 100,
+    ppid: () => 50,
   }
-})
+
+  return {
+    runtime,
+    gitCalls,
+    processCalls,
+    lockExists: () => lockExists,
+    unlinkCalls: () => unlinkCalls,
+  }
+}
+
+interface DecisionOutput {
+  decision?: string
+  reason?: string
+  hookSpecificOutput?: {
+    permissionDecision?: string
+    permissionDecisionReason?: string
+  }
+}
+
+function decisionFrom(result: DecisionOutput): { decision?: string; reason?: string } {
+  return {
+    decision: result.hookSpecificOutput?.permissionDecision ?? result.decision,
+    reason: result.hookSpecificOutput?.permissionDecisionReason ?? result.reason,
+  }
+}
 
 async function runHook(
   command: string,
-  cwd: string
+  harness: Harness,
+  input: { tool_name: string; tool_input: Record<string, unknown> } = {
+    tool_name: "Bash",
+    tool_input: { command },
+  }
 ): Promise<{ decision?: string; reason?: string }> {
   const result = await evaluatePretooluseGitIndexLock(
-    {
-      tool_name: "Bash",
-      tool_input: { command },
-      cwd,
-    },
+    { ...input, cwd: REPO_ROOT },
     {
       lockReleaseTimeoutMs: 100,
       waitIntervalMs: 5,
       removeRetryDelayMs: 5,
+      runtime: harness.runtime,
     }
   )
-  const hookSpecificOutput = (result as Record<string, any>).hookSpecificOutput
-  return {
-    decision: hookSpecificOutput?.permissionDecision ?? (result as Record<string, any>).decision,
-    reason: hookSpecificOutput?.permissionDecisionReason ?? (result as Record<string, any>).reason,
-  }
+  return decisionFrom(result)
 }
 
 describe("pretooluse-git-index-lock", () => {
-  // Each auto-resolve test uses its own isolated repo to avoid concurrent lock contention.
-  describe("auto-resolves stale locks (no active git process)", () => {
-    test(
-      "git status is allowed after stale lock auto-removal",
-      async () => {
-        const repo = await createLockedRepo("auto-resolve-status")
-        const result = await runHook("git status", repo)
+  describe("process inspection", () => {
+    test("bounds process inspection and checks candidate pids in one lsof call", async () => {
+      let now = 1_000
+      const calls: Array<{ cmd: string[]; timeoutMs?: number }> = []
+      const candidatePids = Array.from({ length: 184 }, (_, index) => index + 200)
+
+      const active = await inspectGitProcessesForRepo("/repo", now + 100, {
+        now: () => now,
+        pid: () => 100,
+        ppid: () => 50,
+        spawn: (cmd, options) => {
+          calls.push({ cmd, timeoutMs: options.timeoutMs })
+          now += 25
+          if (cmd[0] === "pgrep") {
+            return Promise.resolve(processResult(candidatePids.join("\n")))
+          }
+          if (cmd[0] === "ps") {
+            return Promise.resolve(processResult("PID PPID\n100 50\n50 1"))
+          }
+          return Promise.resolve(processResult(""))
+        },
+      })
+
+      expect(active).toBe(false)
+      expect(calls).toHaveLength(3)
+      expect(calls[2]?.cmd).toEqual([
+        "lsof",
+        "-a",
+        "-p",
+        candidatePids.join(","),
+        "-d",
+        "cwd",
+        "-Fn",
+      ])
+      expect(calls.map((call) => call.timeoutMs)).toEqual([100, 75, 50])
+    })
+
+    test("detects a candidate process using the repository", async () => {
+      const harness = createHarness({ activeGit: true })
+      const active = await inspectGitProcessesForRepo(REPO_ROOT, 1_100, harness.runtime)
+
+      expect(active).toBe(true)
+      expect(harness.processCalls.map((cmd) => cmd[0])).toEqual(["pgrep", "ps", "lsof"])
+    })
+
+    test("fails safe when process inspection exceeds the deadline", async () => {
+      const harness = createHarness({ processInspectionTimesOut: true })
+      const active = await inspectGitProcessesForRepo(REPO_ROOT, 1_100, harness.runtime)
+
+      expect(active).toBe(true)
+      expect(harness.processCalls).toHaveLength(1)
+    })
+  })
+
+  describe("stale lock resolution", () => {
+    for (const command of [
+      "git status",
+      'git commit -m "test"',
+      "git add .",
+      "echo hello | git log",
+    ]) {
+      test(`allows ${command} after stale lock removal`, async () => {
+        const harness = createHarness()
+        const result = await runHook(command, harness)
+
         expect(result.decision).toBe("allow")
         expect(result.reason).toContain("Auto-removed")
-        expect(result.reason).toContain("index.lock")
-      },
-      { timeout: 30_000 }
-    )
+        expect(harness.lockExists()).toBe(false)
+        expect(harness.unlinkCalls()).toBe(1)
+      })
+    }
 
-    test(
-      "git commit is allowed after stale lock auto-removal",
-      async () => {
-        const repo = await createLockedRepo("auto-resolve-commit")
-        const result = await runHook('git commit -m "test"', repo)
-        expect(result.decision).toBe("allow")
-        expect(result.reason).toContain("Auto-removed")
-      },
-      { timeout: 30_000 }
-    )
+    test("retries a transient unlink failure", async () => {
+      const harness = createHarness({ unlinkFailures: 1 })
+      const result = await runHook("git status", harness)
 
-    test(
-      "git add is allowed after stale lock auto-removal",
-      async () => {
-        const repo = await createLockedRepo("auto-resolve-add")
-        const result = await runHook("git add .", repo)
-        expect(result.decision).toBe("allow")
-      },
-      { timeout: 30_000 }
-    )
-
-    test(
-      "piped git command is allowed after stale lock auto-removal",
-      async () => {
-        const repo = await createLockedRepo("auto-resolve-piped")
-        const result = await runHook("echo hello | git log", repo)
-        expect(result.decision).toBe("allow")
-      },
-      { timeout: 30_000 }
-    )
-
-    test(
-      "lock file is actually removed after auto-resolution",
-      async () => {
-        const repo = await createLockedRepo("auto-resolve-verify")
-        await runHook("git status", repo)
-        const lockPath = joinGitPath(repo, GIT_INDEX_LOCK)
-        const exists = await Bun.file(lockPath).exists()
-        expect(exists).toBe(false)
-      },
-      { timeout: 30_000 }
-    )
-
-    test(
-      "worktree lock is resolved from the dispatching directory git dir",
-      async () => {
-        const { worktree, lockPath } = await createLockedWorktree("auto-resolve-worktree")
-        const result = await runHook("git status", worktree)
-        expect(result.decision).toBe("allow")
-        expect(await Bun.file(lockPath).exists()).toBe(false)
-      },
-      { timeout: 30_000 }
-    )
-  })
-
-  describe("denies when lock cannot be removed", () => {
-    test(
-      "git command is allowed when transient permissions release before deadline",
-      async () => {
-        const repo = await createLockedRepo("transient-permission-release")
-        const gitDir = join(repo, ".git")
-        Bun.spawnSync(["chmod", "500", gitDir])
-        const restorePermissions = (async () => {
-          await Bun.sleep(20)
-          Bun.spawnSync(["chmod", "755", gitDir])
-        })()
-
-        try {
-          const result = await runHook("git status", repo)
-          expect(result.decision).toBe("allow")
-          expect(result.reason).toContain("Auto-removed")
-        } finally {
-          Bun.spawnSync(["chmod", "755", gitDir])
-          await restorePermissions
-        }
-      },
-      { timeout: 30_000 }
-    )
-
-    test(
-      "git command is denied after retries on an immutable lock",
-      async () => {
-        const repo = await createLockedRepo("deny-immutable")
-        const lockPath = joinGitPath(repo, GIT_INDEX_LOCK)
-        const gitDir = join(repo, ".git")
-        // Make the lock file immutable so unlink will fail.
-        // macOS: chflags uchg; Linux: chmod 000 on parent directory.
-        try {
-          const chflagsProc = Bun.spawn(["chflags", "uchg", lockPath], {
-            stdout: "pipe",
-            stderr: "pipe",
-          })
-          await chflagsProc.exited
-          if (chflagsProc.exitCode !== 0) throw new Error("chflags failed")
-        } catch {
-          // Linux fallback: restrict the parent .git directory.
-          Bun.spawnSync(["chmod", "500", gitDir])
-        }
-        const result = await runHook("git status", repo)
-        expect(result.decision).toBe("deny")
-        expect(result.reason).toContain("index.lock")
-        expect(result.reason).toContain("retrying for up to")
-        // Restore permissions so cleanup can remove the repo.
-        try {
-          Bun.spawnSync(["chflags", "nouchg", lockPath])
-        } catch {
-          Bun.spawnSync(["chmod", "755", gitDir])
-        }
-      },
-      { timeout: 30_000 }
-    )
-  })
-
-  describe("allows git commands when no lock", () => {
-    test("git status is allowed", async () => {
-      const result = await runHook("git status", REPO_WITHOUT_LOCK)
-      expect(result.decision).toBeUndefined()
+      expect(result.decision).toBe("allow")
+      expect(harness.unlinkCalls()).toBe(2)
+      expect(harness.lockExists()).toBe(false)
     })
 
-    test("git commit is allowed", async () => {
-      const result = await runHook('git commit -m "test"', REPO_WITHOUT_LOCK)
-      expect(result.decision).toBeUndefined()
+    test("denies when every unlink attempt fails", async () => {
+      const harness = createHarness({ unlinkAlwaysFails: true })
+      const result = await runHook("git status", harness)
+
+      expect(result.decision).toBe("deny")
+      expect(result.reason).toContain("index.lock")
+      expect(result.reason).toContain("retrying for up to")
+      expect(harness.lockExists()).toBe(true)
+    })
+
+    test("allows when the lock disappears during inspection", async () => {
+      const harness = createHarness({ disappearAfterValidation: true })
+      const result = await runHook("git status", harness)
+
+      expect(result.decision).toBe("allow")
+      expect(result.reason).toContain("resolved automatically")
+      expect(harness.unlinkCalls()).toBe(0)
     })
   })
 
-  describe("handles lock disappearing during check", () => {
-    test("allows when lock is removed before hook runs", async () => {
-      const repo = await createLockedRepo("disappear-before-hook")
-      // Remove the lock before running the hook — simulates another process clearing it.
-      await Bun.file(joinGitPath(repo, GIT_INDEX_LOCK)).delete()
-      const result = await runHook("git status", repo)
-      // No lock → early exit with no output
-      expect(result.decision).toBeUndefined()
+  describe("active process handling", () => {
+    test("denies a recent lock while a repository git process is active", async () => {
+      const harness = createHarness({ activeGit: true })
+      const result = await runHook("git status", harness)
+
+      expect(result.decision).toBe("deny")
+      expect(result.reason).toContain("active git process")
+      expect(harness.unlinkCalls()).toBe(0)
+    })
+
+    test("removes an old lock despite a matching long-lived process", async () => {
+      const harness = createHarness({ activeGit: true, lockOld: true })
+      const result = await runHook("git status", harness)
+
+      expect(result.decision).toBe("allow")
+      expect(result.reason).toContain("Auto-removed")
+      expect(harness.lockExists()).toBe(false)
+    })
+
+    test("denies safely when process inspection times out", async () => {
+      const harness = createHarness({ processInspectionTimesOut: true })
+      const result = await runHook("git status", harness)
+
+      expect(result.decision).toBe("deny")
+      expect(result.reason).toContain("active git process")
+      expect(harness.unlinkCalls()).toBe(0)
     })
   })
 
-  describe("passes through non-git commands", () => {
-    test("bun test passes through", async () => {
-      const repo = await createLockedRepo("passthrough-bun")
-      const result = await runHook("bun test", repo)
-      expect(result.decision).toBeUndefined()
-    })
+  describe("early exits", () => {
+    for (const command of ["git status", 'git commit -m "test"']) {
+      test(`allows ${command} when no lock exists`, async () => {
+        const harness = createHarness({ lockExists: false })
+        const result = await runHook(command, harness)
 
-    test("ls passes through", async () => {
-      const repo = await createLockedRepo("passthrough-ls")
-      const result = await runHook("ls -la", repo)
-      expect(result.decision).toBeUndefined()
-    })
+        expect(result.decision).toBeUndefined()
+        expect(harness.processCalls).toHaveLength(0)
+      })
+    }
 
-    test("non-shell tools pass through", async () => {
-      const repo = await createLockedRepo("passthrough-read")
-      const result = await evaluatePretooluseGitIndexLock({
+    for (const command of ["bun test", "ls -la"]) {
+      test(`passes through ${command}`, async () => {
+        const harness = createHarness()
+        const result = await runHook(command, harness)
+
+        expect(result.decision).toBeUndefined()
+        expect(harness.gitCalls).toHaveLength(0)
+        expect(harness.processCalls).toHaveLength(0)
+      })
+    }
+
+    test("passes through non-shell tools", async () => {
+      const harness = createHarness()
+      const result = await runHook("unused", harness, {
         tool_name: "Read",
         tool_input: { file_path: "/some/file" },
-        cwd: repo,
       })
-      expect(result).toEqual({})
+
+      expect(result.decision).toBeUndefined()
+      expect(harness.gitCalls).toHaveLength(0)
+      expect(harness.processCalls).toHaveLength(0)
+    })
+  })
+
+  describe("real Git contract", () => {
+    const tmp = useTempDir("swiz-git-index-lock-contract-")
+
+    test("resolves a worktree lock from the dispatching git directory", async () => {
+      const parent = await tmp.create()
+      const main = join(parent, "main")
+      const worktree = join(parent, "worktree")
+      await mkdir(main, { recursive: true })
+      await runGit(main, ["init"])
+      await runGit(main, [
+        "-c",
+        "user.name=Swiz Test",
+        "-c",
+        "user.email=swiz-test@example.invalid",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "init",
+      ])
+      await runGit(main, ["worktree", "add", worktree])
+
+      const gitDir = await runGit(worktree, ["rev-parse", "--absolute-git-dir"])
+      const lockPath = join(gitDir, GIT_INDEX_LOCK)
+      await Bun.write(lockPath, "")
+
+      const result = await evaluatePretooluseGitIndexLock(
+        {
+          tool_name: "Bash",
+          tool_input: { command: "git status" },
+          cwd: worktree,
+        },
+        {
+          lockReleaseTimeoutMs: 100,
+          waitIntervalMs: 5,
+          removeRetryDelayMs: 5,
+          runtime: {
+            spawn: () => Promise.resolve(processResult("", { exitCode: 1 })),
+          },
+        }
+      )
+
+      expect(decisionFrom(result).decision).toBe("allow")
+      expect(await Bun.file(lockPath).exists()).toBe(false)
     })
   })
 })

--- a/hooks/pretooluse-git-index-lock.test.ts
+++ b/hooks/pretooluse-git-index-lock.test.ts
@@ -20,6 +20,8 @@ interface HarnessOptions {
   unlinkFailures?: number
   unlinkAlwaysFails?: boolean
   processInspectionTimesOut?: boolean
+  processInspectionThrowsOn?: "pgrep" | "ps" | "lsof"
+  lsofExitCode?: number
 }
 
 interface Harness {
@@ -74,6 +76,9 @@ function createHarness(options: HarnessOptions = {}): Harness {
     },
     spawn(cmd) {
       processCalls.push(cmd)
+      if (cmd[0] === options.processInspectionThrowsOn) {
+        throw new Error(`synthetic ${cmd[0]} spawn failure`)
+      }
       if (options.processInspectionTimesOut) {
         now += 100
         return Promise.resolve(processResult("", { timedOut: true }))
@@ -87,6 +92,9 @@ function createHarness(options: HarnessOptions = {}): Harness {
         return Promise.resolve(processResult("PID PPID\n200 1\n100 50\n50 1"))
       }
       if (cmd[0] === "lsof") {
+        if (options.lsofExitCode !== undefined) {
+          return Promise.resolve(processResult("", { exitCode: options.lsofExitCode }))
+        }
         return Promise.resolve(
           processResult(options.activeGit ? `p200\nn${REPO_ROOT}` : "p200\nn/other")
         )
@@ -200,6 +208,25 @@ describe("pretooluse-git-index-lock", () => {
       expect(active).toBe(true)
       expect(harness.processCalls).toHaveLength(1)
     })
+
+    test("fails safe when a process inspection command cannot start", async () => {
+      const harness = createHarness({
+        activeGit: true,
+        processInspectionThrowsOn: "lsof",
+      })
+      const active = await inspectGitProcessesForRepo(REPO_ROOT, 1_100, harness.runtime)
+
+      expect(active).toBe(true)
+      expect(harness.processCalls.map((cmd) => cmd[0])).toEqual(["pgrep", "ps", "lsof"])
+    })
+
+    test("treats an empty non-zero lsof result as a vanished candidate", async () => {
+      const harness = createHarness({ activeGit: true, lsofExitCode: 1 })
+      const active = await inspectGitProcessesForRepo(REPO_ROOT, 1_100, harness.runtime)
+
+      expect(active).toBe(false)
+      expect(harness.processCalls.map((cmd) => cmd[0])).toEqual(["pgrep", "ps", "lsof"])
+    })
   })
 
   describe("stale lock resolution", () => {
@@ -261,6 +288,19 @@ describe("pretooluse-git-index-lock", () => {
 
     test("removes an old lock despite a matching long-lived process", async () => {
       const harness = createHarness({ activeGit: true, lockOld: true })
+      const result = await runHook("git status", harness)
+
+      expect(result.decision).toBe("allow")
+      expect(result.reason).toContain("Auto-removed")
+      expect(harness.lockExists()).toBe(false)
+    })
+
+    test("removes an old lock when process inspection cannot start", async () => {
+      const harness = createHarness({
+        activeGit: true,
+        lockOld: true,
+        processInspectionThrowsOn: "lsof",
+      })
       const result = await runHook("git status", harness)
 
       expect(result.decision).toBe("allow")

--- a/hooks/pretooluse-git-index-lock.ts
+++ b/hooks/pretooluse-git-index-lock.ts
@@ -324,6 +324,18 @@ function lsofOutputUsesRepo(stdout: string, repoRoot: string): boolean {
 
 type ProcessInspectionRuntime = Pick<GitIndexLockRuntime, "now" | "pid" | "ppid" | "spawn">
 
+async function spawnForProcessInspection(
+  runtime: ProcessInspectionRuntime,
+  cmd: string[],
+  timeoutMs: number
+): Promise<SpawnWithTimeoutResult | null> {
+  try {
+    return await runtime.spawn(cmd, { timeoutMs })
+  } catch {
+    return null
+  }
+}
+
 /**
  * Inspect running Git processes without allowing subprocess work to exceed the
  * lock-release deadline. Candidate PIDs are checked in one lsof invocation so
@@ -336,9 +348,12 @@ export async function inspectGitProcessesForRepo(
 ): Promise<boolean> {
   const pgrepTimeoutMs = boundedTimeoutMs(deadlineMs, 3_000, runtime)
   if (pgrepTimeoutMs === null) return true
-  const pgrepResult = await runtime.spawn(["pgrep", "-f", "git"], {
-    timeoutMs: pgrepTimeoutMs,
-  })
+  const pgrepResult = await spawnForProcessInspection(
+    runtime,
+    ["pgrep", "-f", "git"],
+    pgrepTimeoutMs
+  )
+  if (pgrepResult === null) return true
   if (pgrepResult.timedOut) return true
   if (pgrepResult.exitCode !== 0) return false
 
@@ -353,9 +368,8 @@ export async function inspectGitProcessesForRepo(
 
   const psTimeoutMs = boundedTimeoutMs(deadlineMs, 3_000, runtime)
   if (psTimeoutMs === null) return true
-  const psResult = await runtime.spawn(["ps", "-eo", "pid,ppid"], {
-    timeoutMs: psTimeoutMs,
-  })
+  const psResult = await spawnForProcessInspection(runtime, ["ps", "-eo", "pid,ppid"], psTimeoutMs)
+  if (psResult === null) return true
   if (psResult.timedOut || psResult.exitCode !== 0) return true
 
   const ancestors = walkAncestry(parseParentMap(psResult.stdout), runtime.ppid())
@@ -365,12 +379,15 @@ export async function inspectGitProcessesForRepo(
 
   const lsofTimeoutMs = boundedTimeoutMs(deadlineMs, LSOF_TIMEOUT_MS, runtime)
   if (lsofTimeoutMs === null) return true
-  const lsofResult = await runtime.spawn(
+  const lsofResult = await spawnForProcessInspection(
+    runtime,
     ["lsof", "-a", "-p", nonAncestorPids.join(","), "-d", "cwd", "-Fn"],
-    { timeoutMs: lsofTimeoutMs }
+    lsofTimeoutMs
   )
-  if (lsofResult.timedOut || lsofResult.exitCode !== 0) return true
-  return lsofOutputUsesRepo(lsofResult.stdout, repoRoot)
+  if (lsofResult === null || lsofResult.timedOut) return true
+  if (lsofOutputUsesRepo(lsofResult.stdout, repoRoot)) return true
+  if (lsofResult.stdout.trim().length > 0 || lsofResult.exitCode === 0) return false
+  return lsofResult.stderr.trim().length > 0
 }
 
 export async function evaluatePretooluseGitIndexLock(

--- a/hooks/pretooluse-git-index-lock.ts
+++ b/hooks/pretooluse-git-index-lock.ts
@@ -22,7 +22,7 @@ import {
   preToolUseDeny,
 } from "../src/utils/hook-utils.ts"
 import { formatActionPlan } from "../src/utils/inline-hook-helpers.ts"
-import { spawnWithTimeout } from "../src/utils/process-utils.ts"
+import { type SpawnWithTimeoutResult, spawnWithTimeout } from "../src/utils/process-utils.ts"
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -38,12 +38,49 @@ export interface GitIndexLockEvaluationOptions {
   lockReleaseTimeoutMs?: number
   waitIntervalMs?: number
   removeRetryDelayMs?: number
+  runtime?: Partial<GitIndexLockRuntime>
+}
+
+/** External operations injected into the evaluator for deterministic tests. */
+export interface GitIndexLockRuntime {
+  git(args: string[], cwd: string): Promise<string>
+  fileExists(path: string): Promise<boolean>
+  unlink(path: string): Promise<void>
+  fileMtimeMs(path: string): Promise<number>
+  spawn(
+    cmd: string[],
+    options: { cwd?: string; timeoutMs?: number; stdin?: string }
+  ): Promise<SpawnWithTimeoutResult>
+  sleep(ms: number): Promise<void>
+  now(): number
+  pid(): number
+  ppid(): number
+}
+
+const defaultRuntime: GitIndexLockRuntime = {
+  git,
+  fileExists: async (path) => await Bun.file(path).exists(),
+  unlink,
+  fileMtimeMs: async (path) => (await Bun.file(path).stat()).mtimeMs,
+  spawn: spawnWithTimeout,
+  sleep: async (ms) => {
+    if (ms <= 0) return
+    await new Promise((resolve) => setTimeout(resolve, ms))
+  },
+  now: Date.now,
+  pid: () => process.pid,
+  ppid: () => process.ppid,
+}
+
+function resolveRuntime(overrides: Partial<GitIndexLockRuntime> = {}): GitIndexLockRuntime {
+  return { ...defaultRuntime, ...overrides }
 }
 
 // ── Validation & resolution ─────────────────────────────────────────────────
 
 async function validateMainInputs(
-  input: ShellHookInput
+  input: ShellHookInput,
+  runtime: GitIndexLockRuntime
 ): Promise<{ repoRoot: string; lockPath: string } | null> {
   // Only applies to shell tools running git commands.
   if (!isShellTool(input.tool_name ?? "")) return null
@@ -54,15 +91,15 @@ async function validateMainInputs(
   const cwd = input.cwd || process.cwd()
 
   // Find the repo root — handles subdirectories and worktrees.
-  const repoRoot = await git(["rev-parse", "--show-toplevel"], cwd)
+  const repoRoot = await runtime.git(["rev-parse", "--show-toplevel"], cwd)
   if (!repoRoot) return null // Not in a git repo; let git itself report the error.
 
-  const gitDir = await git(["rev-parse", "--absolute-git-dir"], cwd)
+  const gitDir = await runtime.git(["rev-parse", "--absolute-git-dir"], cwd)
   if (!gitDir) return null
   const lockPath = join(gitDir, GIT_INDEX_LOCK)
 
   // Quick exit if no lock exists
-  if (!(await Bun.file(lockPath).exists())) return null
+  if (!(await runtime.fileExists(lockPath))) return null
 
   return { repoRoot, lockPath }
 }
@@ -70,19 +107,21 @@ async function validateMainInputs(
 async function handleLockResolution(
   lockPath: string,
   repoRoot: string,
-  options: GitIndexLockEvaluationOptions = {}
+  options: GitIndexLockEvaluationOptions,
+  runtime: GitIndexLockRuntime
 ): Promise<SwizHookOutput> {
   const lockReleaseTimeoutMs = options.lockReleaseTimeoutMs ?? LOCK_RELEASE_TIMEOUT_MS
   const waitIntervalMs = options.waitIntervalMs ?? WAIT_INTERVAL_MS
   const removeRetryDelayMs = options.removeRetryDelayMs ?? REMOVE_RETRY_DELAY_MS
-  const releaseDeadlineMs = Date.now() + lockReleaseTimeoutMs
+  const releaseDeadlineMs = runtime.now() + lockReleaseTimeoutMs
 
   // Wait for lock to resolve or git process to finish
   const { lockExists, gitActive } = await waitForLockResolution(
     lockPath,
     repoRoot,
     releaseDeadlineMs,
-    waitIntervalMs
+    waitIntervalMs,
+    runtime
   )
 
   if (!lockExists) {
@@ -94,19 +133,21 @@ async function handleLockResolution(
       lockPath,
       releaseDeadlineMs,
       removeRetryDelayMs,
-      lockReleaseTimeoutMs
+      lockReleaseTimeoutMs,
+      runtime
     )
   }
 
   // Git process appears active, but the lock may be stale if it's old enough.
   // Attempt removal for aged locks — pgrep false-positives are common.
-  const lockAge = await getLockAgeMs(lockPath)
+  const lockAge = await getLockAgeMs(lockPath, runtime)
   if (lockAge >= STALE_LOCK_AGE_MS) {
     return await autoRemoveStaleLock(
       lockPath,
       releaseDeadlineMs,
       removeRetryDelayMs,
-      lockReleaseTimeoutMs
+      lockReleaseTimeoutMs,
+      runtime
     )
   }
 
@@ -134,26 +175,27 @@ async function autoRemoveStaleLock(
   lockPath: string,
   releaseDeadlineMs: number,
   removeRetryDelayMs: number,
-  lockReleaseTimeoutMs: number
+  lockReleaseTimeoutMs: number,
+  runtime: GitIndexLockRuntime
 ): Promise<SwizHookOutput> {
   let attempt = 0
 
   // Retry until the shared release deadline to handle transient permissions,
   // racing cleanup, and short-lived lock recreation.
-  while (attempt === 0 || Date.now() < releaseDeadlineMs) {
+  while (attempt === 0 || runtime.now() < releaseDeadlineMs) {
     attempt++
     try {
       // Lock may have already been removed by another process or a prior attempt.
-      if (!(await Bun.file(lockPath).exists())) {
+      if (!(await runtime.fileExists(lockPath))) {
         return preToolUseAllow(
           `\`${LOCK_RELATIVE_PATH}\` resolved (attempt ${attempt}) — proceeding.`
         )
       }
 
-      await unlink(lockPath)
+      await runtime.unlink(lockPath)
 
       // Verify removal succeeded (race condition: another process may have recreated it).
-      if (!(await Bun.file(lockPath).exists())) {
+      if (!(await runtime.fileExists(lockPath))) {
         return preToolUseAllow(
           `Auto-removed stale \`${LOCK_RELATIVE_PATH}\` on attempt ${attempt} — proceeding.`
         )
@@ -162,19 +204,19 @@ async function autoRemoveStaleLock(
       // Lock reappeared — retry if attempts remain.
     } catch {
       // ENOENT (lock vanished between exists() and unlink()) — that's fine.
-      if (!(await Bun.file(lockPath).exists())) {
+      if (!(await runtime.fileExists(lockPath))) {
         return preToolUseAllow(`\`${LOCK_RELATIVE_PATH}\` disappeared during cleanup — proceeding.`)
       }
       // Permission error or similar — retry if attempts remain.
     }
 
-    const remainingMs = releaseDeadlineMs - Date.now()
+    const remainingMs = releaseDeadlineMs - runtime.now()
     if (remainingMs <= 0) break
-    await sleep(Math.min(removeRetryDelayMs, remainingMs))
+    await runtime.sleep(Math.min(removeRetryDelayMs, remainingMs))
   }
 
   // All retries exhausted — do NOT let the git command through if the lock still exists.
-  if (!(await Bun.file(lockPath).exists())) {
+  if (!(await runtime.fileExists(lockPath))) {
     return preToolUseAllow(`Auto-removed stale \`${LOCK_RELATIVE_PATH}\` — proceeding.`)
   }
 
@@ -201,34 +243,28 @@ async function waitForLockResolution(
   lockPath: string,
   repoRoot: string,
   releaseDeadlineMs: number,
-  waitIntervalMs: number
+  waitIntervalMs: number,
+  runtime: GitIndexLockRuntime
 ) {
   let gitActive = true
   let lockExists = true
 
-  while (Date.now() < releaseDeadlineMs) {
-    lockExists = await Bun.file(lockPath).exists()
+  while (runtime.now() < releaseDeadlineMs) {
+    lockExists = await runtime.fileExists(lockPath)
     if (!lockExists) break
 
-    gitActive = await isGitProcessActiveForRepo(repoRoot)
+    gitActive = await inspectGitProcessesForRepo(repoRoot, releaseDeadlineMs, runtime)
     if (!gitActive) break
 
-    await sleep(Math.min(waitIntervalMs, releaseDeadlineMs - Date.now()))
+    await runtime.sleep(Math.min(waitIntervalMs, releaseDeadlineMs - runtime.now()))
   }
 
   return { lockExists, gitActive }
 }
 
-async function sleep(ms: number): Promise<void> {
-  if (ms <= 0) return
-  await new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-async function getLockAgeMs(lockPath: string): Promise<number> {
+async function getLockAgeMs(lockPath: string, runtime: GitIndexLockRuntime): Promise<number> {
   try {
-    const file = Bun.file(lockPath)
-    const stat = await file.stat()
-    return Date.now() - stat.mtimeMs
+    return runtime.now() - (await runtime.fileMtimeMs(lockPath))
   } catch {
     return 0
   }
@@ -243,40 +279,7 @@ async function getLockAgeMs(lockPath: string): Promise<number> {
  *      (e.g., git push -> pre-push hook -> bun -> this hook).
  *   2. Repo scope: exclude git processes whose CWD is outside our repo root.
  */
-async function isGitProcessActiveForRepo(repoRoot: string): Promise<boolean> {
-  const gitPids = await getRunningGitPids()
-  if (gitPids.length === 0) return false
-
-  const ancestors = await getAncestorPids()
-
-  // Filter out ancestor PIDs and this process itself.
-  const nonAncestorPids = gitPids.filter((pid) => pid !== process.pid && !ancestors.has(pid))
-  if (nonAncestorPids.length === 0) return false
-
-  // Check each remaining pid individually so one slow/unresponsive process
-  // does not force a global timeout classification.
-  for (const pid of nonAncestorPids) {
-    if (await isPidUsingRepoDir(pid, repoRoot)) {
-      return true
-    }
-  }
-
-  return false
-}
-
-// ── Low-Level Utilities ──────────────────────────────────────────────────────
-
-async function getRunningGitPids(): Promise<number[]> {
-  const result = await spawnWithTimeout(["pgrep", "-f", "git"], { timeoutMs: 3_000 })
-  if (result.timedOut || result.exitCode !== 0) return []
-  return compact(result.stdout.trim().split("\n").map(Number))
-}
-
-async function buildParentMap(): Promise<Map<number, number>> {
-  const result = await spawnWithTimeout(["ps", "-eo", "pid,ppid"], { timeoutMs: 3_000 })
-  if (result.timedOut) return new Map<number, number>()
-  const out = result.stdout
-
+function parseParentMap(out: string): Map<number, number> {
   const parentMap = new Map<number, number>()
   for (const line of out.trim().split("\n").slice(1)) {
     const parts = line.trim().split(/\s+/)
@@ -288,9 +291,9 @@ async function buildParentMap(): Promise<Map<number, number>> {
   return parentMap
 }
 
-function walkAncestry(parentMap: Map<number, number>): Set<number> {
+function walkAncestry(parentMap: Map<number, number>, startPpid: number): Set<number> {
   const ancestors = new Set<number>()
-  let cur = process.ppid
+  let cur = startPpid
   for (let i = 0; i < MAX_ANCESTRY_DEPTH && cur > 1; i++) {
     ancestors.add(cur)
     const ppid = parentMap.get(cur)
@@ -300,27 +303,74 @@ function walkAncestry(parentMap: Map<number, number>): Set<number> {
   return ancestors
 }
 
-async function getAncestorPids(): Promise<Set<number>> {
-  const parentMap = await buildParentMap()
-  return walkAncestry(parentMap)
+function boundedTimeoutMs(
+  deadlineMs: number,
+  maximumMs: number,
+  runtime: Pick<GitIndexLockRuntime, "now">
+): number | null {
+  const remainingMs = deadlineMs - runtime.now()
+  if (remainingMs <= 0) return null
+  return Math.max(1, Math.min(maximumMs, remainingMs))
 }
 
-async function isPidUsingRepoDir(pid: number, repoRoot: string): Promise<boolean> {
-  try {
-    const result = await spawnWithTimeout(["lsof", "-p", String(pid), "-d", "cwd", "-Fn"], {
-      timeoutMs: LSOF_TIMEOUT_MS,
-    })
+function lsofOutputUsesRepo(stdout: string, repoRoot: string): boolean {
+  const repoPrefix = repoRoot.endsWith("/") ? repoRoot : `${repoRoot}/`
+  return stdout.split("\n").some((line) => {
+    if (!line.startsWith("n")) return false
+    const path = line.slice(1)
+    return path === repoRoot || path.startsWith(repoPrefix)
+  })
+}
 
-    if (result.timedOut) return false
+type ProcessInspectionRuntime = Pick<GitIndexLockRuntime, "now" | "pid" | "ppid" | "spawn">
 
-    return result.stdout
+/**
+ * Inspect running Git processes without allowing subprocess work to exceed the
+ * lock-release deadline. Candidate PIDs are checked in one lsof invocation so
+ * long-lived fsmonitor daemons cannot multiply the timeout.
+ */
+export async function inspectGitProcessesForRepo(
+  repoRoot: string,
+  deadlineMs: number,
+  runtime: ProcessInspectionRuntime = defaultRuntime
+): Promise<boolean> {
+  const pgrepTimeoutMs = boundedTimeoutMs(deadlineMs, 3_000, runtime)
+  if (pgrepTimeoutMs === null) return true
+  const pgrepResult = await runtime.spawn(["pgrep", "-f", "git"], {
+    timeoutMs: pgrepTimeoutMs,
+  })
+  if (pgrepResult.timedOut) return true
+  if (pgrepResult.exitCode !== 0) return false
+
+  const gitPids = compact(
+    pgrepResult.stdout
+      .trim()
       .split("\n")
-      .some((line) => line.startsWith("n") && line.slice(1).startsWith(repoRoot))
-  } catch {
-    // If lsof fails or is not in PATH, we cannot safely determine the process's working directory.
-    // Assume it might be using this repo to prevent concurrent index modification.
-    return true
-  }
+      .map(Number)
+      .filter((pid) => Number.isInteger(pid) && pid > 0)
+  )
+  if (gitPids.length === 0) return false
+
+  const psTimeoutMs = boundedTimeoutMs(deadlineMs, 3_000, runtime)
+  if (psTimeoutMs === null) return true
+  const psResult = await runtime.spawn(["ps", "-eo", "pid,ppid"], {
+    timeoutMs: psTimeoutMs,
+  })
+  if (psResult.timedOut || psResult.exitCode !== 0) return true
+
+  const ancestors = walkAncestry(parseParentMap(psResult.stdout), runtime.ppid())
+  const currentPid = runtime.pid()
+  const nonAncestorPids = gitPids.filter((pid) => pid !== currentPid && !ancestors.has(pid))
+  if (nonAncestorPids.length === 0) return false
+
+  const lsofTimeoutMs = boundedTimeoutMs(deadlineMs, LSOF_TIMEOUT_MS, runtime)
+  if (lsofTimeoutMs === null) return true
+  const lsofResult = await runtime.spawn(
+    ["lsof", "-a", "-p", nonAncestorPids.join(","), "-d", "cwd", "-Fn"],
+    { timeoutMs: lsofTimeoutMs }
+  )
+  if (lsofResult.timedOut || lsofResult.exitCode !== 0) return true
+  return lsofOutputUsesRepo(lsofResult.stdout, repoRoot)
 }
 
 export async function evaluatePretooluseGitIndexLock(
@@ -328,10 +378,11 @@ export async function evaluatePretooluseGitIndexLock(
   options: GitIndexLockEvaluationOptions = {}
 ): Promise<SwizHookOutput> {
   try {
+    const runtime = resolveRuntime(options.runtime)
     const parsed = shellHookInputSchema.parse(input)
-    const validated = await validateMainInputs(parsed)
+    const validated = await validateMainInputs(parsed, runtime)
     if (!validated) return {}
-    return await handleLockResolution(validated.lockPath, validated.repoRoot, options)
+    return await handleLockResolution(validated.lockPath, validated.repoRoot, options, runtime)
   } catch (err: unknown) {
     const message = messageFromUnknownError(err)
     return preToolUseDeny(

--- a/hooks/pretooluse-protect-sandbox.test.ts
+++ b/hooks/pretooluse-protect-sandbox.test.ts
@@ -1,14 +1,11 @@
-import { describe, expect, setDefaultTimeout, test } from "bun:test"
-
-setDefaultTimeout(30_000)
-
+import { describe, expect, test } from "bun:test"
 import { homedir } from "node:os"
-import { join, resolve } from "node:path"
+import { join } from "node:path"
 import {
-  extractPreToolSurfaceDecision,
-  getHookSpecificOutput,
-} from "../src/utils/hook-specific-output.ts"
-import { neutralAgentEnv, runFileEditHook } from "../src/utils/test-utils.ts"
+  neutralAgentEnvOverrides,
+  runFileEditHook,
+  runHookInProcess,
+} from "../src/utils/test-utils.ts"
 import { isSandboxDisableCommand, isTrunkModeDisableCommand } from "./pretooluse-protect-sandbox.ts"
 
 const HOOK = "hooks/pretooluse-protect-sandbox.ts"
@@ -18,39 +15,19 @@ async function runPinnedHomeBashHook(
   command: string,
   opts: { agent?: "codex"; cwd?: string } = {}
 ): Promise<{ decision?: string; stdout: string }> {
-  const proc = Bun.spawn(["bun", resolve(process.cwd(), HOOK)], {
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-    cwd: opts.cwd,
-    env: neutralAgentEnv({ HOME: TEST_HOME, SWIZ_DAEMON_PORT: "19999" }),
-  })
-  await proc.stdin.write(
-    JSON.stringify({
+  const result = await runHookInProcess(
+    HOOK,
+    {
       ...(opts.agent ? { _agent: opts.agent } : {}),
       tool_name: "Bash",
       tool_input: { command },
-    })
-  )
-  await proc.stdin.end()
-
-  const out = await new Response(proc.stdout).text()
-  await proc.exited
-
-  const stdout = out.trim()
-  if (!stdout) return { stdout }
-
-  try {
-    const parsed = JSON.parse(stdout) as Record<string, any>
-    const surface = extractPreToolSurfaceDecision(parsed)
-    if (surface.decision || surface.reason) {
-      return { ...surface, stdout }
+    },
+    {
+      cwd: opts.cwd,
+      env: neutralAgentEnvOverrides({ HOME: TEST_HOME, SWIZ_DAEMON_PORT: "19999" }),
     }
-    const hso = getHookSpecificOutput(parsed)
-    return hso?.hookEventName === "PreToolUse" ? { decision: "allow", stdout } : { stdout }
-  } catch {
-    return { stdout }
-  }
+  )
+  return { decision: result.decision, stdout: result.stdout.trim() }
 }
 
 describe("isSandboxDisableCommand", () => {

--- a/hooks/pretooluse-trunk-mode-branch-gate.test.ts
+++ b/hooks/pretooluse-trunk-mode-branch-gate.test.ts
@@ -1,17 +1,34 @@
-import { describe, expect, setDefaultTimeout, test } from "bun:test"
-import { mkdir, rm, writeFile } from "node:fs/promises"
-import { join } from "node:path"
-import { writeProjectState } from "../src/settings.ts"
-import { createTestRepo } from "../src/utils/test-utils.ts"
+import { describe, expect, test } from "bun:test"
+import { evaluatePretooluseTrunkModeBranchGate } from "./pretooluse-trunk-mode-branch-gate.ts"
 
-setDefaultTimeout(30_000)
+const trunkModeRepos = new Set<string>()
+const projectStates = new Map<string, string>()
+const openPrCounts = new Map<string, number>()
+let nextRepoId = 0
 
-const BUN_EXE = Bun.which("bun") ?? "bun"
-const WORKSPACE_ROOT = process.cwd()
+function createTestRepo(
+  _remote: string,
+  _options: { featureBranch?: string } = {}
+): Promise<string> {
+  nextRepoId += 1
+  return Promise.resolve(`/test/trunk-mode-repo-${nextRepoId}`)
+}
 
-async function enableTrunkMode(repo: string): Promise<void> {
-  await mkdir(join(repo, ".swiz"), { recursive: true })
-  await writeFile(join(repo, ".swiz", "config.json"), JSON.stringify({ trunkMode: true }))
+function enableTrunkMode(repo: string): Promise<void> {
+  trunkModeRepos.add(repo)
+  return Promise.resolve()
+}
+
+function writeProjectState(repo: string, state: string): Promise<void> {
+  projectStates.set(repo, state)
+  return Promise.resolve()
+}
+
+function cleanupTestPath(path: string): Promise<void> {
+  trunkModeRepos.delete(path)
+  projectStates.delete(path)
+  openPrCounts.delete(path)
+  return Promise.resolve()
 }
 
 async function runHook(
@@ -20,59 +37,49 @@ async function runHook(
   toolName = "Bash",
   envOverrides: Record<string, string | undefined> = {}
 ): Promise<{ raw: string; parsed: Record<string, any> | null; decision?: string }> {
-  const payload = JSON.stringify({
-    tool_name: toolName,
-    tool_input: { command, cwd },
-    cwd,
-  })
-
-  const proc = Bun.spawn([BUN_EXE, "hooks/pretooluse-trunk-mode-branch-gate.ts"], {
-    cwd: WORKSPACE_ROOT,
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-    env: { ...process.env, ...envOverrides },
-  })
-  await proc.stdin.write(payload)
-  await proc.stdin.end()
-  const [rawOutput, stderrOutput] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ])
-  const exitCode = await proc.exited
-  const raw = rawOutput.trim()
-  const stderr = stderrOutput.trim()
-  if (exitCode !== 0) {
-    throw new Error(`hook exited with ${exitCode}: ${stderr || "(no stderr)"}`)
-  }
-  if (!raw) return { raw, parsed: null }
-  const parsed = JSON.parse(raw) as Record<string, any>
-  const hso = parsed.hookSpecificOutput as Record<string, any> | undefined
-  const decision = (hso?.permissionDecision as string) ?? (parsed.decision as string) ?? undefined
+  const output = await evaluatePretooluseTrunkModeBranchGate(
+    {
+      tool_name: toolName,
+      tool_input: { command, cwd },
+      cwd,
+    },
+    {
+      runtime: {
+        isGitRepo: () => Promise.resolve(true),
+        readProjectSettings: (repo) =>
+          Promise.resolve(trunkModeRepos.has(repo) ? { trunkMode: true } : null),
+        readProjectState: (repo) => Promise.resolve(projectStates.get(repo) ?? null),
+        getDefaultBranch: () => Promise.resolve("main"),
+        hasOpenPullRequests: () => {
+          const mockBin = [...openPrCounts.keys()].find((path) =>
+            envOverrides.PATH?.startsWith(`${path}:`)
+          )
+          return Promise.resolve(mockBin ? (openPrCounts.get(mockBin) ?? 0) > 0 : false)
+        },
+      },
+    }
+  )
+  const parsed = Object.keys(output).length > 0 ? (output as Record<string, any>) : null
+  const raw = parsed ? JSON.stringify(parsed) : ""
+  const hso = parsed?.hookSpecificOutput as Record<string, any> | undefined
+  const decision =
+    (hso?.permissionDecision as string) ?? (parsed?.decision as string | undefined) ?? undefined
   return { raw, parsed, decision }
 }
 
-async function createMockGhBin(openPrCount: number): Promise<string> {
-  const dir = await Bun.$`mktemp -d`.text()
-  const binDir = dir.trim()
-  const ghPath = join(binDir, "gh")
-  await writeFile(
-    ghPath,
-    `#!/bin/sh
-if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
-  if [ "${openPrCount}" = "0" ]; then
-    echo "[]"
-  else
-    echo '[{"number":42}]'
-  fi
-  exit 0
-fi
-echo "[]"
-exit 0
-`
-  )
-  await Bun.$`chmod +x ${ghPath}`
-  return binDir
+function createMockGhBin(openPrCount: number): Promise<string> {
+  const binDir = `/test/mock-gh-${openPrCounts.size + 1}`
+  openPrCounts.set(binDir, openPrCount)
+  return Promise.resolve(binDir)
+}
+
+async function cleanupRepoAndMock(repo: string, mockGhBin?: string): Promise<void> {
+  if (mockGhBin) await cleanupTestPath(mockGhBin)
+  await cleanupTestPath(repo)
+}
+
+async function cleanupRepo(repo: string): Promise<void> {
+  await cleanupTestPath(repo)
 }
 
 describe("pretooluse-trunk-mode-branch-gate", () => {
@@ -82,7 +89,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       const result = await runHook(repo, "git checkout -b feat/off")
       expect(result.parsed).toBeNull()
     } finally {
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepo(repo)
     }
   })
 
@@ -96,7 +103,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       expect(String(hso?.permissionDecisionReason ?? "")).toContain("Trunk mode")
       expect(String(hso?.permissionDecisionReason ?? "")).toContain("feat/trunk-block")
     } finally {
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepo(repo)
     }
   })
 
@@ -109,7 +116,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       const result = await runHook(repo, "git checkout main")
       expect(result.parsed).toBeNull()
     } finally {
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepo(repo)
     }
   })
 
@@ -128,7 +135,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
         const result = await runHook(repo, command)
         expect(result.parsed).toBeNull()
       } finally {
-        await rm(repo, { recursive: true, force: true })
+        await cleanupRepo(repo)
       }
     })
   }
@@ -142,7 +149,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       const result = await runHook(repo, "git checkout -b main")
       expect(result.parsed).toBeNull()
     } finally {
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepo(repo)
     }
   })
 
@@ -172,7 +179,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
         const hso = result.parsed?.hookSpecificOutput as Record<string, any>
         expect(String(hso?.permissionDecisionReason ?? "")).toContain("Trunk mode")
       } finally {
-        await rm(repo, { recursive: true, force: true })
+        await cleanupRepo(repo)
       }
     })
   }
@@ -189,7 +196,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
         const result = await runHook(repo, command)
         expect(result.parsed).toBeNull()
       } finally {
-        await rm(repo, { recursive: true, force: true })
+        await cleanupRepo(repo)
       }
     })
   }
@@ -201,7 +208,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       const result = await runHook(repo, "git checkout main && git checkout -b feat/second")
       expect(result.decision).toBe("deny")
     } finally {
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepo(repo)
     }
   })
 
@@ -214,7 +221,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       const hso = result.parsed?.hookSpecificOutput as Record<string, any>
       expect(String(hso?.permissionDecisionReason ?? "")).toMatch(/pull request|PR/i)
     } finally {
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepo(repo)
     }
   })
 
@@ -230,8 +237,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       })
       expect(result.parsed).toBeNull()
     } finally {
-      await rm(mockGhBin, { recursive: true, force: true })
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepoAndMock(repo, mockGhBin)
     }
   })
 
@@ -247,8 +253,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       })
       expect(result.decision).toBe("deny")
     } finally {
-      await rm(mockGhBin, { recursive: true, force: true })
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepoAndMock(repo, mockGhBin)
     }
   })
 
@@ -266,8 +271,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       const hso = result.parsed?.hookSpecificOutput as Record<string, any>
       expect(String(hso?.permissionDecisionReason ?? "")).toContain("developing")
     } finally {
-      await rm(mockGhBin, { recursive: true, force: true })
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepoAndMock(repo, mockGhBin)
     }
   })
 
@@ -281,7 +285,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       expect(String(hso?.permissionDecisionReason ?? "")).toMatch(/pull request|PR/i)
       expect(String(hso?.permissionDecisionReason ?? "")).toMatch(/trunk mode/i)
     } finally {
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepo(repo)
     }
   })
 
@@ -291,7 +295,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       const result = await runHook(repo, "gh pr create --fill")
       expect(result.parsed).toBeNull()
     } finally {
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepo(repo)
     }
   })
 
@@ -302,7 +306,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       const result = await runHook(repo, "git checkout -b feat/x", "Read")
       expect(result.parsed).toBeNull()
     } finally {
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepo(repo)
     }
   })
 
@@ -313,7 +317,7 @@ describe("pretooluse-trunk-mode-branch-gate", () => {
       const result = await runHook(repo, "git status")
       expect(result.parsed).toBeNull()
     } finally {
-      await rm(repo, { recursive: true, force: true })
+      await cleanupRepo(repo)
     }
   })
 })

--- a/hooks/pretooluse-trunk-mode-branch-gate.ts
+++ b/hooks/pretooluse-trunk-mode-branch-gate.ts
@@ -44,7 +44,7 @@ function denyPrCreateWhenTrunk(command: string, defaultBranch: string): SwizHook
   )
 }
 
-async function hasOpenPullRequests(cwd: string): Promise<boolean> {
+async function queryOpenPullRequests(cwd: string): Promise<boolean> {
   const prs = await ghJson<Array<{ number?: number }>>(
     ["pr", "list", "--state", "open", "--json", "number", "--limit", "1"],
     cwd
@@ -52,14 +52,36 @@ async function hasOpenPullRequests(cwd: string): Promise<boolean> {
   return Array.isArray(prs) && prs.length > 0
 }
 
+export interface TrunkModeBranchGateRuntime {
+  isGitRepo(cwd: string): Promise<boolean>
+  readProjectSettings(cwd: string): Promise<{ trunkMode?: boolean } | null>
+  readProjectState(cwd: string): Promise<string | null>
+  getDefaultBranch(cwd: string): Promise<string>
+  hasOpenPullRequests(cwd: string): Promise<boolean>
+}
+
+export interface TrunkModeBranchGateOptions {
+  /** Override process, settings, and repository boundaries for deterministic evaluation. */
+  runtime?: Partial<TrunkModeBranchGateRuntime>
+}
+
+const defaultRuntime: TrunkModeBranchGateRuntime = {
+  isGitRepo,
+  readProjectSettings,
+  readProjectState,
+  getDefaultBranch,
+  hasOpenPullRequests: queryOpenPullRequests,
+}
+
 async function denyPrCheckoutWhenTrunk(
   command: string,
   defaultBranch: string,
   cwd: string,
-  projectState: string | null
+  projectState: string | null,
+  runtime: TrunkModeBranchGateRuntime
 ): Promise<SwizHookOutput | null> {
   if (!GH_PR_CHECKOUT_RE.test(command)) return null
-  if (projectState === "reviewing" && (await hasOpenPullRequests(cwd))) return null
+  if (projectState === "reviewing" && (await runtime.hasOpenPullRequests(cwd))) return null
 
   if (projectState === "developing") {
     return preToolUseDeny(
@@ -121,19 +143,21 @@ function resolveTrunkShellRequest(input: unknown): TrunkShellRequest {
 
 async function shouldEnforceTrunkMode(
   request: TrunkShellRequest,
-  branchChanges: GitBranchChange[]
+  branchChanges: GitBranchChange[],
+  runtime: TrunkModeBranchGateRuntime
 ): Promise<boolean> {
   if (!isShellTool(request.toolName)) return false
   if (!isTrunkModeRelevantShellCommand(request.command, branchChanges)) return false
-  if (!(await isGitRepo(request.cwd))) return false
-  return (await readProjectSettings(request.cwd))?.trunkMode === true
+  if (!(await runtime.isGitRepo(request.cwd))) return false
+  return (await runtime.readProjectSettings(request.cwd))?.trunkMode === true
 }
 
 async function selectTrunkModeDenial(
   request: TrunkShellRequest,
   branchChanges: GitBranchChange[],
   defaultBranch: string,
-  projectState: string | null
+  projectState: string | null,
+  runtime: TrunkModeBranchGateRuntime
 ): Promise<SwizHookOutput | null> {
   const prCreate = denyPrCreateWhenTrunk(request.command, defaultBranch)
   if (prCreate) return prCreate
@@ -142,21 +166,27 @@ async function selectTrunkModeDenial(
     request.command,
     defaultBranch,
     request.cwd,
-    projectState
+    projectState,
+    runtime
   )
   return prCheckout ?? denyBranchChangesWhenTrunk(branchChanges, defaultBranch)
 }
 
 export async function evaluatePretooluseTrunkModeBranchGate(
-  input: unknown
+  input: unknown,
+  options: TrunkModeBranchGateOptions = {}
 ): Promise<SwizHookOutput> {
+  const runtime = { ...defaultRuntime, ...options.runtime }
   const request = resolveTrunkShellRequest(input)
   const branchChanges = collectGitBranchChanges(request.command)
-  if (!(await shouldEnforceTrunkMode(request, branchChanges))) return {}
+  if (!(await shouldEnforceTrunkMode(request, branchChanges, runtime))) return {}
 
-  const projectState = await readProjectState(request.cwd)
-  const defaultBranch = await getDefaultBranch(request.cwd)
-  return (await selectTrunkModeDenial(request, branchChanges, defaultBranch, projectState)) ?? {}
+  const projectState = await runtime.readProjectState(request.cwd)
+  const defaultBranch = await runtime.getDefaultBranch(request.cwd)
+  return (
+    (await selectTrunkModeDenial(request, branchChanges, defaultBranch, projectState, runtime)) ??
+    {}
+  )
 }
 
 const pretooluseTrunkModeBranchGate: SwizToolHook = {

--- a/src/commands/daemon/cache/file-watcher-registry.test.ts
+++ b/src/commands/daemon/cache/file-watcher-registry.test.ts
@@ -69,27 +69,43 @@ describe("file-watcher-registry exclusion", () => {
   })
 
   test("debounces burst invalidations", async () => {
-    const base = join("/tmp/swiz-watcher-test-debounce", `run-${Date.now()}`)
-    mkdirSync(base, { recursive: true })
-    const registry = new FileWatcherRegistry()
+    const captured: {
+      emitChange?: (event: string, filename: string | null) => void
+      flushDebounce?: () => void
+    } = {}
+    const registry = new FileWatcherRegistry({
+      watch: (_path, _options, listener) => {
+        captured.emitChange = listener
+        return { close: () => {} }
+      },
+      schedule: (callback) => {
+        captured.flushDebounce = callback
+        return Symbol("debounce-timer")
+      },
+      cancel: () => {},
+      now: () => 1234,
+    })
     let invalidations = 0
     try {
-      registry.register(join(base, "/"), "test-debounce", () => {
+      registry.register("/virtual/project/", "test-debounce", () => {
         invalidations += 1
       })
       await registry.start()
 
-      const watchedFile = join(base, "watched.txt")
-      await Bun.write(watchedFile, "one")
-      await Bun.write(watchedFile, "two")
-      await Bun.write(watchedFile, "three")
-      await Bun.sleep(200)
+      expect(captured.emitChange).toBeDefined()
+      captured.emitChange?.("change", "watched.txt")
+      captured.emitChange?.("change", "watched.txt")
+      captured.emitChange?.("change", "watched.txt")
+      expect(invalidations).toBe(0)
+
+      expect(captured.flushDebounce).toBeDefined()
+      captured.flushDebounce?.()
 
       expect(invalidations).toBe(1)
       expect(registry.status()[0]?.invalidationCount).toBe(1)
+      expect(registry.status()[0]?.lastInvalidation).toBe(1234)
     } finally {
       registry.close()
-      safeRemove(base)
     }
   })
 })

--- a/src/commands/daemon/cache/file-watcher-registry.ts
+++ b/src/commands/daemon/cache/file-watcher-registry.ts
@@ -1,11 +1,27 @@
-import { type FSWatcher, watch } from "node:fs"
+import { watch } from "node:fs"
+
+export interface FileWatcherHandle {
+  close(): void
+}
+
+export interface FileWatcherRuntime {
+  /** Watch and scheduling boundaries are injectable so debounce behavior stays deterministic in tests. */
+  watch(
+    path: string,
+    options: { recursive: boolean },
+    listener: (event: string, filename: string | Buffer | null) => void
+  ): FileWatcherHandle
+  schedule(callback: () => void, delayMs: number): unknown
+  cancel(timer: unknown): void
+  now(): number
+}
 
 export interface WatchEntry {
   path: string
   label: string
   callbacks: Set<() => void>
-  watchers: FSWatcher[]
-  debounceTimer: ReturnType<typeof setTimeout> | null
+  watchers: FileWatcherHandle[]
+  debounceTimer: unknown | null
   lastInvalidation: number | null
   invalidationCount: number
   recursive?: boolean
@@ -13,6 +29,13 @@ export interface WatchEntry {
 }
 
 const WATCH_INVALIDATION_DEBOUNCE_MS = 50
+
+const defaultRuntime: FileWatcherRuntime = {
+  watch: (path, options, listener) => watch(path, options, listener),
+  schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+  cancel: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+  now: () => Date.now(),
+}
 
 /**
  * Registry of file-system watchers that trigger cache invalidation callbacks.
@@ -29,6 +52,11 @@ const WATCH_INVALIDATION_DEBOUNCE_MS = 50
  */
 export class BaseFileWatcherRegistry {
   private entries = new Map<string, WatchEntry>()
+  private runtime: FileWatcherRuntime
+
+  constructor(runtime: Partial<FileWatcherRuntime> = {}) {
+    this.runtime = { ...defaultRuntime, ...runtime }
+  }
 
   register(
     path: string,
@@ -62,7 +90,7 @@ export class BaseFileWatcherRegistry {
 
       const flush = () => {
         entry.debounceTimer = null
-        entry.lastInvalidation = Date.now()
+        entry.lastInvalidation = this.runtime.now()
         entry.invalidationCount += 1
         for (const cb of entry.callbacks) {
           try {
@@ -73,24 +101,28 @@ export class BaseFileWatcherRegistry {
         }
       }
       const fire = () => {
-        if (entry.debounceTimer) return
-        entry.debounceTimer = setTimeout(flush, WATCH_INVALIDATION_DEBOUNCE_MS)
+        if (entry.debounceTimer !== null) return
+        entry.debounceTimer = this.runtime.schedule(flush, WATCH_INVALIDATION_DEBOUNCE_MS)
       }
 
       if (entry.recursive && entry.depth !== 0) {
         try {
-          const watcher = watch(entry.path, { recursive: true }, (_event, filename) => {
-            const rel = filename == null ? "" : `${filename}`
-            if (this.shouldIgnoreRelativePath(rel)) return
-            fire()
-          })
+          const watcher = this.runtime.watch(
+            entry.path,
+            { recursive: true },
+            (_event, filename) => {
+              const rel = filename == null ? "" : `${filename}`
+              if (this.shouldIgnoreRelativePath(rel)) return
+              fire()
+            }
+          )
           entry.watchers.push(watcher)
         } catch {
           // path may not exist yet — that's fine
         }
       } else {
         try {
-          const watcher = watch(entry.path, { recursive: false }, fire)
+          const watcher = this.runtime.watch(entry.path, { recursive: false }, fire)
           entry.watchers.push(watcher)
         } catch {
           // path may not exist yet — that's fine
@@ -134,8 +166,8 @@ export class BaseFileWatcherRegistry {
     let removed = 0
     for (const [path, entry] of this.entries) {
       if (entry.label.endsWith(suffix)) {
-        if (entry.debounceTimer) {
-          clearTimeout(entry.debounceTimer)
+        if (entry.debounceTimer !== null) {
+          this.runtime.cancel(entry.debounceTimer)
           entry.debounceTimer = null
         }
         for (const w of entry.watchers) {
@@ -151,8 +183,8 @@ export class BaseFileWatcherRegistry {
 
   close(): void {
     for (const entry of this.entries.values()) {
-      if (entry.debounceTimer) {
-        clearTimeout(entry.debounceTimer)
+      if (entry.debounceTimer !== null) {
+        this.runtime.cancel(entry.debounceTimer)
         entry.debounceTimer = null
       }
       for (const w of entry.watchers) {

--- a/src/utils/test-utils.test.ts
+++ b/src/utils/test-utils.test.ts
@@ -1,5 +1,12 @@
 import { expect, test } from "bun:test"
-import { acquireEnvLock, releaseEnvLockFn } from "./test-utils.ts"
+import { acquireEnvLock, neutralAgentEnv, releaseEnvLockFn } from "./test-utils.ts"
+
+test("missing HOME subprocesses disable Bun's relative transpiler cache", () => {
+  const env = neutralAgentEnv({ HOME: undefined })
+
+  expect(env.HOME).toBe("")
+  expect(env.BUN_RUNTIME_TRANSPILER_CACHE_PATH).toBe("0")
+})
 
 test("environment lock releases queued callers in acquisition order", async () => {
   const order: string[] = []

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -248,7 +248,8 @@ export const AGENT_ENV_KEYS = [
 /**
  * Merge `process.env` with overrides. Keys set to `undefined` are removed.
  * `HOME: undefined` becomes `HOME: ""` because Bun.spawn re-injects the real
- * home from the OS when `HOME` is omitted from the env object.
+ * home from the OS when `HOME` is omitted from the env object. Its transpiler
+ * cache is disabled in that case so Bun does not create a relative `Library/`.
  */
 function mergeHookEnv(overrides: Record<string, string | undefined>): Record<string, string> {
   const env: Record<string, string> = {}
@@ -264,6 +265,9 @@ function mergeHookEnv(overrides: Record<string, string | undefined>): Record<str
   }
   if (Object.hasOwn(overrides, "HOME") && overrides.HOME === undefined) {
     env.HOME = ""
+    if (!Object.hasOwn(overrides, "BUN_RUNTIME_TRANSPILER_CACHE_PATH")) {
+      env.BUN_RUNTIME_TRANSPILER_CACHE_PATH = "0"
+    }
   }
   return env
 }


### PR DESCRIPTION
## Summary

Make timeout-prone hook tests deterministic by replacing repeated process, Git, filesystem, and timer boundaries with injected runtimes or the in-process hook harness.

## What changed

- Bound git index-lock process inspection to the shared release deadline and inspect candidate PIDs with one `lsof` call.
- Keep one real Git worktree contract while mocking process inspection in behavioral index-lock tests.
- Inject repository, settings, transcript, GitHub, watcher, clock, and timer boundaries where tests only need behavior.
- Run the negative-path and sandbox-protection behavior suites through the existing in-process hook runner.
- Replace the watcher debounce test's real `fs.watch` delivery and sleep with deterministic callbacks.
- Preserve subprocess coverage for missing-`HOME` contracts while disabling Bun's relative transpiler cache for those tests.

## Why

The index-lock suite could exceed 30 seconds when `pgrep -f git` found many long-lived processes, because it ran a separate timed `lsof` call for every PID. Several other behavioral suites had the same symptom at a smaller scale: every case launched Bun or depended on live Git/filesystem state.

## Testing

- `bun run typecheck`
- Missing-`HOME`, negative-path, and hardening regression set: 126 tests passed.
- Full suite: 8,298 passed, 1 skipped, 49 todo, 0 failed across 325 files.
- Full-suite command: `bun test --reporter=dots --parallel=4`

## Performance evidence

- Index-lock suite: 30-second timeout to about 185 ms.
- Trunk-mode branch gate: about 22.8 s aggregate to 122 ms.
- Pre-existing dismissal gate: about 12.2 s aggregate to 133 ms.
- Negative-path regression: about 13.4 s aggregate to 1.35 s.
- Sandbox protection: about 8.5 s aggregate to 122 ms.
- Watcher debounce: deterministic callback execution with no 200 ms sleep.

## Risk / rollout

Low. Production runtimes retain the existing real dependencies by default. The index-lock path now fails safe when process inspection times out or errors, and exact repository path boundaries prevent prefix collisions.
