### PR TITLE
test(hooks): remove shared test counters

### DIFF
--- a/hooks/stop-auto-continue.test.ts
+++ b/hooks/stop-auto-continue.test.ts
@@ -47,8 +47,6 @@ function buildTranscript(toolCallCount: number, userMessage = "What is the statu
   return `${lines.join("\n")}\n`
 }
 
-let sessionCounter = 0
-
 async function runHook({
   transcriptContent,
   stopHookActive = false,
@@ -71,7 +69,7 @@ async function runHook({
   const payload = JSON.stringify({
     transcript_path: transcriptPath,
     stop_hook_active: stopHookActive,
-    session_id: sessionId ?? `test-session-${++sessionCounter}`,
+    session_id: sessionId ?? `test-session-${crypto.randomUUID()}`,
     cwd: hookCwd,
   })
 

--- a/hooks/stop-secret-scanner.test.ts
+++ b/hooks/stop-secret-scanner.test.ts
@@ -9,10 +9,9 @@ import { scanDiffForSecrets } from "./stop-secret-scanner.ts"
 const tmp = useTempDir("swiz-secret-scanner-")
 const GIT_EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 const mockDiffs = new Map<string, string>()
-let nextRepoId = 0
 
 function makeRepo(): string {
-  const cwd = `/mock/swiz-secret-scanner-${++nextRepoId}`
+  const cwd = `/mock/swiz-secret-scanner-${crypto.randomUUID()}`
   mockDiffs.set(cwd, "")
   return cwd
 }


### PR DESCRIPTION
## Summary

- replace module-level test identity counters with per-invocation UUIDs
- preserve explicit session ID overrides and existing test behavior
- leave `src/utils/auto-steer-helpers.test.ts` unchanged because the reported fetch mutation is no longer present

## Why

Shared mutable counters can leak state between concurrently executed test files. Local UUID generation removes ordering dependencies without adding reset hooks or changing production behavior.

Closes #703

## Testing

- `bun test hooks/stop-secret-scanner.test.ts hooks/stop-auto-continue.test.ts --reporter=dots --parallel=2` — 88 passed
- `bun test --reporter=dots --parallel=4` — 8,303 passed, 1 skipped, 49 todo, 0 failed
- `bun run typecheck` — passed
- `bun run lint` — passed with 0 errors
- lefthook pre-push targeted suite — 88 passed

## Risk / Rollout

Low risk. The change is limited to test fixture identity generation and does not affect runtime behavior.

## Screenshots / Evidence

Not applicable; test-only change.
