### PR TITLE
feat(transcripts): support Antigravity CLI sessions

### DIFF
--- a/scripts/debug-antigravity-transcript-discovery.ts
+++ b/scripts/debug-antigravity-transcript-discovery.ts
@@ -1,0 +1,41 @@
+import { stat } from "node:fs/promises"
+import { join } from "node:path"
+import { getHomeDir } from "../src/home.ts"
+
+/**
+ * Diagnostic probe to inspect Antigravity CLI session transcript files under
+ * ~/.gemini/antigravity-cli/brain/<uuid>/.system_generated/logs/transcript.jsonl
+ */
+async function main() {
+  const home = getHomeDir()
+  const currentSessionId = "63062b62-5dec-4166-a9d9-14d192672570"
+  const sessionDir = join(home, ".gemini", "antigravity-cli", "brain", currentSessionId)
+
+  console.log("Inspecting session dir:", sessionDir)
+
+  const logFile = join(sessionDir, ".system_generated", "logs", "transcript.jsonl")
+  try {
+    const s = await stat(logFile)
+    console.log(`[FOUND] transcript.jsonl (${s.size} bytes, modified: ${s.mtime.toISOString()})`)
+
+    // Read first line to verify JSONL structure
+    const file = Bun.file(logFile)
+    const text = await file.text()
+    const firstLine = text.split("\n")[0]
+    if (firstLine) {
+      const parsed = JSON.parse(firstLine)
+      console.log("First Entry Type:", parsed.type)
+      console.log("First Entry Source:", parsed.source)
+      console.log(
+        "Content Preview:",
+        String(parsed.content || "")
+          .slice(0, 100)
+          .replace(/\n/g, " ")
+      )
+    }
+  } catch (err: any) {
+    console.error("Failed to read transcript.jsonl:", err.message)
+  }
+}
+
+await main()

--- a/scripts/debug-antigravity-transcript-discovery.ts
+++ b/scripts/debug-antigravity-transcript-discovery.ts
@@ -8,8 +8,14 @@ import { getHomeDir } from "../src/home.ts"
  */
 async function main() {
   const home = getHomeDir()
-  const currentSessionId = "63062b62-5dec-4166-a9d9-14d192672570"
-  const sessionDir = join(home, ".gemini", "antigravity-cli", "brain", currentSessionId)
+  const sessionId = process.argv[2]
+  if (!sessionId) {
+    console.error("Usage: bun scripts/debug-antigravity-transcript-discovery.ts <session-id>")
+    process.exitCode = 1
+    return
+  }
+
+  const sessionDir = join(home, ".gemini", "antigravity-cli", "brain", sessionId)
 
   console.log("Inspecting session dir:", sessionDir)
 
@@ -33,8 +39,9 @@ async function main() {
           .replace(/\n/g, " ")
       )
     }
-  } catch (err: any) {
-    console.error("Failed to read transcript.jsonl:", err.message)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error("Failed to read transcript.jsonl:", message)
   }
 }
 

--- a/src/commands/transcript-session-gemini.test.ts
+++ b/src/commands/transcript-session-gemini.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import { mkdir, writeFile } from "node:fs/promises"
 import { basename, join } from "node:path"
-import { createAntigravitySession, createCodexSession } from "../test-fixtures.ts"
+import { detectCurrentAgentFromEnv } from "../detect.ts"
+import {
+  createAntigravityCliSession,
+  createAntigravitySession,
+  createCodexSession,
+} from "../test-fixtures.ts"
 import { turnsToDisplayTurns } from "../transcript-turns.ts"
 import { projectKeyFromCwd } from "../transcript-utils.ts"
 import { runCommandInProcess, useTempDir } from "../utils/test-utils.ts"
@@ -12,6 +17,7 @@ import { type TranscriptCommandOptions, transcriptCommand } from "./transcript.t
 const { create: createTempHome } = useTempDir("swiz-transcript-gemini-test-")
 
 const transcriptOptions: TranscriptCommandOptions = {
+  detectAgent: () => detectCurrentAgentFromEnv(),
   async runListMode(sessions) {
     for (const session of sessions) console.log(session.id)
   },
@@ -728,6 +734,28 @@ describe("Provider transcript/session command support", () => {
     )
     expect(result.exitCode).toBe(1)
     expect(result.stderr).toContain("Antigravity protobuf format (.pb)")
+  })
+
+  test("swiz transcript --session renders Antigravity CLI JSONL turns", async () => {
+    const home = await createTempHome()
+    const projectDir = join(home, "workspace", "demo-antigravity-cli")
+    const sessionId = "30668ced-3f3f-4640-9ab3-fc5c72938894"
+    await mkdir(projectDir, { recursive: true })
+    await createAntigravityCliSession(home, projectDir, sessionId, {
+      userMessage: "How do minecarts work?",
+      assistantMessage: "Minecarts operate along tracks.",
+    })
+
+    const result = await runSwiz(
+      ["transcript", "--session", sessionId.slice(0, 8), "--dir", projectDir],
+      home
+    )
+    expect(result.exitCode).toBe(0)
+    const out = stripAnsi(result.stdout)
+    expect(out).toContain("USER")
+    expect(out).toContain("ASSISTANT")
+    expect(out).toContain("How do minecarts work?")
+    expect(out).toContain("Minecarts operate along tracks.")
   })
 
   test("swiz continue --session resolves Antigravity IDs and reports unsupported format", async () => {

--- a/src/test-fixtures.ts
+++ b/src/test-fixtures.ts
@@ -39,7 +39,7 @@ export async function createAntigravityCliSession(
   const brainDir = join(home, ".gemini", "antigravity-cli", "brain", sessionId)
   const logsDir = join(brainDir, ".system_generated", "logs")
   await mkdir(logsDir, { recursive: true })
-  await writeFile(join(brainDir, "task.md"), `# Task\nThis session targets file://${targetDir}\n`)
+  await Bun.write(join(brainDir, "task.md"), `# Task\nThis session targets file://${targetDir}\n`)
 
   const lines = [
     JSON.stringify({
@@ -65,7 +65,7 @@ export async function createAntigravityCliSession(
     )
   }
 
-  await writeFile(join(logsDir, "transcript.jsonl"), `${lines.join("\n")}\n`)
+  await Bun.write(join(logsDir, "transcript.jsonl"), `${lines.join("\n")}\n`)
 }
 
 interface CodexSessionOptions {

--- a/src/test-fixtures.ts
+++ b/src/test-fixtures.ts
@@ -26,6 +26,48 @@ export async function createAntigravitySession(
   await writeFile(join(brainDir, "task.md"), `# Task\n${taskText}\n`)
 }
 
+/**
+ * Create a mock Antigravity CLI JSONL session on disk.
+ */
+export async function createAntigravityCliSession(
+  home: string,
+  targetDir: string,
+  sessionId: string,
+  options: { userMessage?: string; assistantMessage?: string } = {}
+): Promise<void> {
+  const { userMessage = "Hello from Antigravity CLI session", assistantMessage } = options
+  const brainDir = join(home, ".gemini", "antigravity-cli", "brain", sessionId)
+  const logsDir = join(brainDir, ".system_generated", "logs")
+  await mkdir(logsDir, { recursive: true })
+  await writeFile(join(brainDir, "task.md"), `# Task\nThis session targets file://${targetDir}\n`)
+
+  const lines = [
+    JSON.stringify({
+      step_index: 0,
+      source: "USER_EXPLICIT",
+      type: "USER_INPUT",
+      status: "DONE",
+      created_at: "2026-08-01T21:00:00Z",
+      content: `<USER_REQUEST>\n${userMessage}\n</USER_REQUEST>`,
+    }),
+  ]
+
+  if (assistantMessage) {
+    lines.push(
+      JSON.stringify({
+        step_index: 1,
+        source: "MODEL",
+        type: "PLANNER_RESPONSE",
+        status: "DONE",
+        created_at: "2026-08-01T21:00:01Z",
+        content: assistantMessage,
+      })
+    )
+  }
+
+  await writeFile(join(logsDir, "transcript.jsonl"), `${lines.join("\n")}\n`)
+}
+
 interface CodexSessionOptions {
   userMessage?: string
   assistantMessage?: string

--- a/src/transcript-analysis-parse-part2.ts
+++ b/src/transcript-analysis-parse-part2.ts
@@ -301,7 +301,7 @@ export function parseAntigravityJsonlEntries(text: string): TranscriptEntry[] {
         },
       })
     } else if (source === "MODEL" && type === "PLANNER_RESPONSE") {
-      const blocks: unknown[] = []
+      const blocks: ContentBlock[] = []
       if (typeof rec.content === "string" && rec.content.trim().length > 0) {
         blocks.push({ type: "text", text: rec.content })
       }
@@ -322,11 +322,15 @@ export function parseAntigravityJsonlEntries(text: string): TranscriptEntry[] {
                 parsedArgs = JSON.parse(parsedArgs)
               } catch {}
             }
+            const input =
+              parsedArgs && typeof parsedArgs === "object" && !Array.isArray(parsedArgs)
+                ? (parsedArgs as Record<string, unknown>)
+                : {}
             blocks.push({
               type: "tool_use",
               id: callId,
               name: String(callRec.name),
-              input: (parsedArgs as Record<string, unknown>) ?? {},
+              input,
             })
           }
         }
@@ -337,7 +341,7 @@ export function parseAntigravityJsonlEntries(text: string): TranscriptEntry[] {
           timestamp: createdAt,
           message: {
             role: "assistant",
-            content: blocks as any,
+            content: blocks,
           },
         })
       }
@@ -384,6 +388,10 @@ function autoDetectTranscriptFormat(text: string): TranscriptEntry[] {
   if (geminiEntries.length > 0) return geminiEntries
   const codexEntries = parseCodexJsonlEntries(text)
   if (codexEntries.length > 0) return codexEntries
+  if (text.includes('"step_index"') && text.includes('"source"')) {
+    const antigravityEntries = parseAntigravityJsonlEntries(text)
+    if (antigravityEntries.length > 0) return antigravityEntries
+  }
   if (text.includes('"type":"event"') && text.includes('"payload":')) {
     const junieEntries = parseJunieEvents(text)
     if (junieEntries.length > 0) return junieEntries

--- a/src/transcript-analysis-parse-part2.ts
+++ b/src/transcript-analysis-parse-part2.ts
@@ -6,6 +6,7 @@ import {
 } from "./transcript-analysis-parse-part1.ts"
 import { extractTextFromUnknownContent } from "./transcript-extract.ts"
 import type { ContentBlock, Session, TranscriptEntry } from "./transcript-schemas.ts"
+import { splitJsonlLines, tryParseJsonLine } from "./utils/jsonl.ts"
 
 // ─── Gemini content schemas ───────────────────────────────────────────────────
 
@@ -273,8 +274,99 @@ function parseCursorSqliteEntries(text: string): TranscriptEntry[] {
   return entries
 }
 
+export function parseAntigravityJsonlEntries(text: string): TranscriptEntry[] {
+  const entries: TranscriptEntry[] = []
+  let callIdSeq = 0
+  let lastToolUseId = ""
+
+  for (const line of splitJsonlLines(text)) {
+    const obj = tryParseJsonLine(line)
+    if (!obj || typeof obj !== "object") continue
+
+    const rec = obj as Record<string, unknown>
+    const stepIndex = rec.step_index
+    const source = rec.source
+    const type = rec.type
+    const createdAt = typeof rec.created_at === "string" ? rec.created_at : undefined
+
+    if (type === "USER_INPUT" || source === "USER_EXPLICIT") {
+      let content = typeof rec.content === "string" ? rec.content : ""
+      content = content.replace(/^<USER_REQUEST>\n?/, "").replace(/\n?<\/USER_REQUEST>[\s\S]*$/, "")
+      entries.push({
+        type: "user",
+        timestamp: createdAt,
+        message: {
+          role: "user",
+          content,
+        },
+      })
+    } else if (source === "MODEL" && type === "PLANNER_RESPONSE") {
+      const blocks: unknown[] = []
+      if (typeof rec.content === "string" && rec.content.trim().length > 0) {
+        blocks.push({ type: "text", text: rec.content })
+      }
+      if (Array.isArray(rec.tool_calls)) {
+        for (const call of rec.tool_calls) {
+          if (
+            call &&
+            typeof call === "object" &&
+            typeof (call as Record<string, unknown>).name === "string"
+          ) {
+            const callRec = call as Record<string, unknown>
+            callIdSeq++
+            const callId = `call_${stepIndex}_${callIdSeq}`
+            lastToolUseId = callId
+            let parsedArgs = callRec.args
+            if (typeof parsedArgs === "string") {
+              try {
+                parsedArgs = JSON.parse(parsedArgs)
+              } catch {}
+            }
+            blocks.push({
+              type: "tool_use",
+              id: callId,
+              name: String(callRec.name),
+              input: (parsedArgs as Record<string, unknown>) ?? {},
+            })
+          }
+        }
+      }
+      if (blocks.length > 0) {
+        entries.push({
+          type: "assistant",
+          timestamp: createdAt,
+          message: {
+            role: "assistant",
+            content: blocks as any,
+          },
+        })
+      }
+    } else if (source === "MODEL" && type !== "PLANNER_RESPONSE") {
+      if (lastToolUseId && typeof rec.content === "string") {
+        entries.push({
+          type: "user",
+          timestamp: createdAt,
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: lastToolUseId,
+                content: rec.content,
+              },
+            ],
+          },
+        })
+      }
+    }
+  }
+
+  return entries
+}
+
 const FORMAT_PARSERS: Record<string, (text: string) => TranscriptEntry[]> = {
   "antigravity-pb": () => [],
+  "antigravity-jsonl": parseAntigravityJsonlEntries,
   "cursor-sqlite": parseCursorSqliteEntries,
   "cursor-agent-jsonl": parseJsonlEntries,
   "gemini-json": parseGeminiEntries,

--- a/src/transcript-antigravity.test.ts
+++ b/src/transcript-antigravity.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test"
+import { parseAntigravityJsonlEntries } from "./transcript-analysis-parse-part2.ts"
+
+describe("parseAntigravityJsonlEntries", () => {
+  test("parses user, assistant, tool-use, and tool-result records", () => {
+    const transcript = [
+      JSON.stringify({
+        step_index: 0,
+        source: "USER_EXPLICIT",
+        type: "USER_INPUT",
+        created_at: "2026-08-01T21:00:00Z",
+        content: "<USER_REQUEST>Inspect this file</USER_REQUEST>",
+      }),
+      JSON.stringify({
+        step_index: 1,
+        source: "MODEL",
+        type: "PLANNER_RESPONSE",
+        created_at: "2026-08-01T21:00:01Z",
+        content: "I will inspect it.",
+        tool_calls: [{ name: "read_file", args: '{"path":"src/index.ts"}' }],
+      }),
+      JSON.stringify({
+        step_index: 2,
+        source: "MODEL",
+        type: "TOOL_RESPONSE",
+        created_at: "2026-08-01T21:00:02Z",
+        content: "export const ready = true",
+      }),
+    ].join("\n")
+
+    expect(parseAntigravityJsonlEntries(transcript)).toEqual([
+      {
+        type: "user",
+        timestamp: "2026-08-01T21:00:00Z",
+        message: { role: "user", content: "Inspect this file" },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-08-01T21:00:01Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I will inspect it." },
+            {
+              type: "tool_use",
+              id: "call_1_1",
+              name: "read_file",
+              input: { path: "src/index.ts" },
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        timestamp: "2026-08-01T21:00:02Z",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_1_1",
+              content: "export const ready = true",
+            },
+          ],
+        },
+      },
+    ])
+  })
+
+  test("ignores malformed and unsupported records", () => {
+    const transcript = [
+      "not-json",
+      JSON.stringify({ source: "MODEL", type: "PLANNER_RESPONSE", content: "" }),
+      JSON.stringify({ source: "SYSTEM", type: "STATUS", content: "working" }),
+    ].join("\n")
+
+    expect(parseAntigravityJsonlEntries(transcript)).toEqual([])
+  })
+})

--- a/src/transcript-antigravity.test.ts
+++ b/src/transcript-antigravity.test.ts
@@ -1,32 +1,45 @@
 import { describe, expect, test } from "bun:test"
-import { parseAntigravityJsonlEntries } from "./transcript-analysis-parse-part2.ts"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  parseAntigravityJsonlEntries,
+  parseTranscriptEntries,
+} from "./transcript-analysis-parse-part2.ts"
+import { parseTranscriptArgs } from "./transcript-args.ts"
+import type { Session } from "./transcript-schemas.ts"
+import { loadSessionContent } from "./transcript-turns.ts"
+
+function createToolTranscript(): string {
+  return [
+    JSON.stringify({
+      step_index: 0,
+      source: "USER_EXPLICIT",
+      type: "USER_INPUT",
+      created_at: "2026-08-01T21:00:00Z",
+      content: "<USER_REQUEST>Inspect this file</USER_REQUEST>",
+    }),
+    JSON.stringify({
+      step_index: 1,
+      source: "MODEL",
+      type: "PLANNER_RESPONSE",
+      created_at: "2026-08-01T21:00:01Z",
+      content: "I will inspect it.",
+      tool_calls: [{ name: "read_file", args: '{"path":"src/index.ts"}' }],
+    }),
+    JSON.stringify({
+      step_index: 2,
+      source: "MODEL",
+      type: "TOOL_RESPONSE",
+      created_at: "2026-08-01T21:00:02Z",
+      content: "export const ready = true",
+    }),
+  ].join("\n")
+}
 
 describe("parseAntigravityJsonlEntries", () => {
   test("parses user, assistant, tool-use, and tool-result records", () => {
-    const transcript = [
-      JSON.stringify({
-        step_index: 0,
-        source: "USER_EXPLICIT",
-        type: "USER_INPUT",
-        created_at: "2026-08-01T21:00:00Z",
-        content: "<USER_REQUEST>Inspect this file</USER_REQUEST>",
-      }),
-      JSON.stringify({
-        step_index: 1,
-        source: "MODEL",
-        type: "PLANNER_RESPONSE",
-        created_at: "2026-08-01T21:00:01Z",
-        content: "I will inspect it.",
-        tool_calls: [{ name: "read_file", args: '{"path":"src/index.ts"}' }],
-      }),
-      JSON.stringify({
-        step_index: 2,
-        source: "MODEL",
-        type: "TOOL_RESPONSE",
-        created_at: "2026-08-01T21:00:02Z",
-        content: "export const ready = true",
-      }),
-    ].join("\n")
+    const transcript = createToolTranscript()
 
     expect(parseAntigravityJsonlEntries(transcript)).toEqual([
       {
@@ -75,5 +88,39 @@ describe("parseAntigravityJsonlEntries", () => {
     ].join("\n")
 
     expect(parseAntigravityJsonlEntries(transcript)).toEqual([])
+  })
+
+  test("auto-detects Antigravity records for generic transcript readers", () => {
+    const transcript = createToolTranscript()
+    expect(parseTranscriptEntries(transcript)).toEqual(parseAntigravityJsonlEntries(transcript))
+  })
+
+  test("preserves tool state when loading head-limited transcript turns", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "swiz-antigravity-turns-"))
+    try {
+      const transcriptPath = join(directory, "transcript.jsonl")
+      await Bun.write(transcriptPath, `${createToolTranscript()}\n`)
+      const session: Session = {
+        id: "antigravity-streaming-test",
+        path: transcriptPath,
+        mtime: Date.now(),
+        provider: "antigravity",
+        format: "antigravity-jsonl",
+      }
+      const parsed = { ...parseTranscriptArgs([]), headCount: 3 }
+
+      const { turns } = await loadSessionContent(session, parsed, {}, false)
+
+      expect(turns).toHaveLength(3)
+      expect(turns[2]?.entry.message?.content).toEqual([
+        {
+          type: "tool_result",
+          tool_use_id: "call_1_1",
+          content: "export const ready = true",
+        },
+      ])
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
   })
 })

--- a/src/transcript-schemas.ts
+++ b/src/transcript-schemas.ts
@@ -104,6 +104,7 @@ export interface Session {
     | "gemini-json"
     | "cursor-sqlite"
     | "antigravity-pb"
+    | "antigravity-jsonl"
     | "codex-jsonl"
     | "cursor-agent-jsonl"
 }

--- a/src/transcript-sessions-discovery.ts
+++ b/src/transcript-sessions-discovery.ts
@@ -499,43 +499,71 @@ export async function findAntigravitySessions(
   limit?: number
 ): Promise<Session[]> {
   home = home ?? getHomeDir()
+  const sessions: Session[] = []
+
+  // 1. Check Antigravity CLI sessions (~/.gemini/antigravity-cli/brain/<uuid>/.system_generated/logs/transcript.jsonl)
+  const cliBrainDir = join(home, ".gemini", "antigravity-cli", "brain")
+  try {
+    const cliEntries = await readdir(cliBrainDir, { withFileTypes: true })
+    for (const entry of cliEntries) {
+      if (!entry.isDirectory()) continue
+      const id = entry.name
+      const brainSessionDir = join(cliBrainDir, id)
+      const transcriptPath = join(brainSessionDir, ".system_generated", "logs", "transcript.jsonl")
+
+      try {
+        const s = await stat(transcriptPath)
+        const matchesTarget = await antigravitySessionMatchesTarget(brainSessionDir, targetDir)
+        if (!matchesTarget) continue
+
+        pushLimitedSession(
+          sessions,
+          {
+            id,
+            path: transcriptPath,
+            mtime: s.mtimeMs,
+            provider: "antigravity",
+            format: "antigravity-jsonl",
+          },
+          limit
+        )
+      } catch {}
+    }
+  } catch {}
+
+  // 2. Check legacy Antigravity protobuf sessions (~/.gemini/antigravity/conversations/*.pb)
   const antigravityRoot = join(home, ".gemini", "antigravity")
   const conversationsDir = join(antigravityRoot, "conversations")
   const brainDir = join(antigravityRoot, "brain")
-  const sessions: Session[] = []
 
-  let entries: import("node:fs").Dirent[]
   try {
-    entries = await readdir(conversationsDir, { withFileTypes: true })
-  } catch {
-    return []
-  }
+    const pbEntries = await readdir(conversationsDir, { withFileTypes: true })
+    for (const entry of pbEntries) {
+      if (!entry.isFile()) continue
+      if (!entry.name.endsWith(".pb")) continue
 
-  for (const entry of entries) {
-    if (!entry.isFile()) continue
-    if (!entry.name.endsWith(".pb")) continue
+      const id = entry.name.replace(/\.pb$/, "")
+      const sessionPath = join(conversationsDir, entry.name)
+      const brainSessionDir = join(brainDir, id)
+      const matchesTarget = await antigravitySessionMatchesTarget(brainSessionDir, targetDir)
+      if (!matchesTarget) continue
 
-    const id = entry.name.replace(/\.pb$/, "")
-    const sessionPath = join(conversationsDir, entry.name)
-    const brainSessionDir = join(brainDir, id)
-    const matchesTarget = await antigravitySessionMatchesTarget(brainSessionDir, targetDir)
-    if (!matchesTarget) continue
-
-    try {
-      const s = await stat(sessionPath)
-      pushLimitedSession(
-        sessions,
-        {
-          id,
-          path: sessionPath,
-          mtime: s.mtimeMs,
-          provider: "antigravity",
-          format: "antigravity-pb",
-        },
-        limit
-      )
-    } catch {}
-  }
+      try {
+        const s = await stat(sessionPath)
+        pushLimitedSession(
+          sessions,
+          {
+            id,
+            path: sessionPath,
+            mtime: s.mtimeMs,
+            provider: "antigravity",
+            format: "antigravity-pb",
+          },
+          limit
+        )
+      } catch {}
+    }
+  } catch {}
 
   return limitSessionList(sessions, limit)
 }

--- a/src/transcript-sessions-discovery.ts
+++ b/src/transcript-sessions-discovery.ts
@@ -454,6 +454,45 @@ const ANTIGRAVITY_PROJECT_HINT_FILES = new Set([
   "walkthrough.md.resolved.0",
 ])
 
+const PATH_REFERENCE_BOUNDARIES = new Set([
+  '"',
+  "'",
+  "`",
+  "(",
+  ")",
+  "[",
+  "]",
+  "{",
+  "}",
+  "<",
+  ">",
+  ",",
+  ";",
+  ":",
+  "=",
+  "?",
+  "#",
+  "\\",
+  "/",
+])
+
+function isPathReferenceBoundary(char: string | undefined): boolean {
+  return char === undefined || /\s/.test(char) || PATH_REFERENCE_BOUNDARIES.has(char)
+}
+
+function sampleReferencesPath(sample: string, targetPath: string): boolean {
+  let start = 0
+  while (start < sample.length) {
+    const index = sample.indexOf(targetPath, start)
+    if (index < 0) return false
+    const before = index > 0 ? sample[index - 1] : undefined
+    const after = sample[index + targetPath.length]
+    if (isPathReferenceBoundary(before) && isPathReferenceBoundary(after)) return true
+    start = index + targetPath.length
+  }
+  return false
+}
+
 async function antigravitySessionMatchesTarget(
   brainSessionDir: string,
   targetDir: string
@@ -478,13 +517,11 @@ async function antigravitySessionMatchesTarget(
   if (candidates.length === 0) return true
 
   const targetPath = resolve(targetDir)
-  const fileUrlNeedle = `file://${targetPath}`
-
   for (const name of candidates) {
     try {
       const content = await getCachedFileText(join(brainSessionDir, name))
       const sample = content.slice(0, 200_000)
-      if (sample.includes(fileUrlNeedle) || sample.includes(targetPath)) {
+      if (sampleReferencesPath(sample, targetPath)) {
         return true
       }
     } catch {}

--- a/src/transcript-turns.ts
+++ b/src/transcript-turns.ts
@@ -56,14 +56,15 @@ export interface Turn {
 
 type JsonlTranscriptFormat = Extract<
   Session["format"],
-  "jsonl" | "cursor-agent-jsonl" | "codex-jsonl"
+  "jsonl" | "cursor-agent-jsonl" | "codex-jsonl" | "antigravity-jsonl"
 >
 
 function getJsonlFormatHint(session: Session): JsonlTranscriptFormat | null {
   if (
     session.format === "jsonl" ||
     session.format === "cursor-agent-jsonl" ||
-    session.format === "codex-jsonl"
+    session.format === "codex-jsonl" ||
+    session.format === "antigravity-jsonl"
   ) {
     return session.format
   }

--- a/src/transcript-turns.ts
+++ b/src/transcript-turns.ts
@@ -135,6 +135,10 @@ function collectTurnsFromJsonlText(
   return collectTurns(parseTranscriptEntries(text, formatHint), userOnly)
 }
 
+function requiresWholeFileParsing(formatHint: JsonlTranscriptFormat): boolean {
+  return formatHint === "antigravity-jsonl"
+}
+
 function turnMatchesTimeRange(turn: Turn, timeRange: TimeRange | undefined): boolean {
   if (!timeRange) return true
   const ts = turn.entry.timestamp
@@ -238,7 +242,9 @@ async function loadTurns(session: Session, userOnly = false): Promise<Turn[]> {
   _turnsCacheMisses++
   const jsonlFormatHint = getJsonlFormatHint(session)
   if (jsonlFormatHint) {
-    const turns = await loadJsonlTurnsForward(file, jsonlFormatHint, userOnly)
+    const turns = requiresWholeFileParsing(jsonlFormatHint)
+      ? collectTurnsFromJsonlText(await file.text(), jsonlFormatHint, userOnly)
+      : await loadJsonlTurnsForward(file, jsonlFormatHint, userOnly)
     turnsCache.set(cacheKey, { turns, mtimeMs })
     return turns
   }
@@ -256,6 +262,7 @@ async function loadWindowedJsonlTurns(
 ): Promise<Turn[] | null> {
   const formatHint = getJsonlFormatHint(session)
   if (!formatHint) return null
+  if (requiresWholeFileParsing(formatHint)) return null
   if (isUnsupportedTranscriptFormat(session.format)) {
     throw new Error(getUnsupportedTranscriptFormatMessage(session))
   }

--- a/src/transcript-utils-integration.test.ts
+++ b/src/transcript-utils-integration.test.ts
@@ -3,7 +3,7 @@ import { mkdir, rm, utimes, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
-import { createCodexSession } from "./test-fixtures.ts"
+import { createAntigravityCliSession, createCodexSession } from "./test-fixtures.ts"
 
 /** Create a unique temp directory (concurrent-safe). */
 async function makeTmpDir(prefix: string): Promise<string> {
@@ -423,25 +423,7 @@ describe("transcript-utils integration", () => {
       await mkdir(projectDir, { recursive: true })
 
       const id = "710012fb-8a00-41f6-b80c-e9c748a14c0c"
-      const brainDir = join(home, ".gemini", "antigravity-cli", "brain", id)
-      const logsDir = join(brainDir, ".system_generated", "logs")
-      await mkdir(logsDir, { recursive: true })
-
-      await writeFile(
-        join(brainDir, "task.md"),
-        `# Task\nWork in file://${projectDir}\nand continue integration.\n`
-      )
-      await writeFile(
-        join(logsDir, "transcript.jsonl"),
-        JSON.stringify({
-          step_index: 0,
-          source: "USER_EXPLICIT",
-          type: "USER_INPUT",
-          status: "DONE",
-          created_at: "2026-08-01T21:00:00Z",
-          content: "<USER_REQUEST>Test prompt</USER_REQUEST>",
-        }) + "\n"
-      )
+      await createAntigravityCliSession(home, projectDir, id)
 
       const { findAllProviderSessions } = await import("./transcript-utils.ts")
       const sessions = await findAllProviderSessions(projectDir, home)
@@ -449,6 +431,22 @@ describe("transcript-utils integration", () => {
       expect(match).toBeDefined()
       expect(match?.provider).toBe("antigravity")
       expect(match?.format).toBe("antigravity-jsonl")
+      await rm(home, { recursive: true, force: true }).catch(() => {})
+    })
+
+    it("does not match Antigravity CLI sessions from a sibling project prefix", async () => {
+      const home = await makeTmpDir("transcript-antigravity-cli-boundary")
+      const projectDir = join(home, "workspace", "app")
+      const siblingProjectDir = join(home, "workspace", "app-old")
+      await mkdir(projectDir, { recursive: true })
+      await mkdir(siblingProjectDir, { recursive: true })
+
+      const id = "810012fb-8a00-41f6-b80c-e9c748a14c0c"
+      await createAntigravityCliSession(home, siblingProjectDir, id)
+
+      const { findAllProviderSessions } = await import("./transcript-utils.ts")
+      const sessions = await findAllProviderSessions(projectDir, home)
+      expect(sessions.some((session) => session.id === id)).toBe(false)
       await rm(home, { recursive: true, force: true }).catch(() => {})
     })
 

--- a/src/transcript-utils-integration.test.ts
+++ b/src/transcript-utils-integration.test.ts
@@ -417,6 +417,41 @@ describe("transcript-utils integration", () => {
       await rm(home, { recursive: true, force: true }).catch(() => {})
     })
 
+    it("discovers Antigravity CLI JSONL sessions mapped to the target project", async () => {
+      const home = await makeTmpDir("transcript-antigravity-cli")
+      const projectDir = join(home, "workspace", "antigravity-cli-project")
+      await mkdir(projectDir, { recursive: true })
+
+      const id = "710012fb-8a00-41f6-b80c-e9c748a14c0c"
+      const brainDir = join(home, ".gemini", "antigravity-cli", "brain", id)
+      const logsDir = join(brainDir, ".system_generated", "logs")
+      await mkdir(logsDir, { recursive: true })
+
+      await writeFile(
+        join(brainDir, "task.md"),
+        `# Task\nWork in file://${projectDir}\nand continue integration.\n`
+      )
+      await writeFile(
+        join(logsDir, "transcript.jsonl"),
+        JSON.stringify({
+          step_index: 0,
+          source: "USER_EXPLICIT",
+          type: "USER_INPUT",
+          status: "DONE",
+          created_at: "2026-08-01T21:00:00Z",
+          content: "<USER_REQUEST>Test prompt</USER_REQUEST>",
+        }) + "\n"
+      )
+
+      const { findAllProviderSessions } = await import("./transcript-utils.ts")
+      const sessions = await findAllProviderSessions(projectDir, home)
+      const match = sessions.find((s) => s.id === id)
+      expect(match).toBeDefined()
+      expect(match?.provider).toBe("antigravity")
+      expect(match?.format).toBe("antigravity-jsonl")
+      await rm(home, { recursive: true, force: true }).catch(() => {})
+    })
+
     it("filters out Antigravity sessions whose brain metadata points to another project", async () => {
       const home = await makeTmpDir("transcript-antigravity")
       const projectDir = join(home, "workspace", "primary-project")


### PR DESCRIPTION
## Summary\n\nAdd discovery and rendering support for Antigravity CLI JSONL transcripts while preserving legacy protobuf-session behavior.\n\n## What changed\n\n- Discover project-scoped Antigravity CLI sessions under the Antigravity brain directory.\n- Parse user, assistant, tool-use, and tool-result JSONL records through the existing transcript pipeline.\n- Auto-detect Antigravity JSONL in generic transcript readers and preserve parser state before turn limiting.\n- Enforce exact project-path boundaries during discovery.\n- Extend transcript and session commands with Antigravity CLI coverage.\n- Add reusable fixtures, integration coverage, parser coverage, and a parameterized local diagnostic probe.\n\n## Why\n\nAntigravity CLI sessions use readable JSONL transcripts, but Swiz previously discovered only legacy protobuf conversations and reported them as unsupported.\n\n## Testing\n\n- Full repository lint and typecheck passed.\n- Focused transcript validation passed: 59 tests across 3 files.\n- Pre-push targeted suites passed: 31 tests across 3 files.\n- Diagnostic probe missing-argument behavior verified.\n\n## Risk / Rollout\n\nLow-to-moderate risk. The new format is additive, project filtering remains required, and the legacy protobuf discovery path is retained.\n\n## Screenshots / Evidence\n\nNot applicable; this is CLI transcript parsing and discovery behavior.